### PR TITLE
fix: Duplicated question marks in the generated action url.

### DIFF
--- a/src/Casdoor.Client/Extensions/CasdoorOptionsExtension.cs
+++ b/src/Casdoor.Client/Extensions/CasdoorOptionsExtension.cs
@@ -50,7 +50,7 @@ public static class CasdoorClientOptionsExtension
             }
         }
         string query = queryBuilder.ToString();
-        return $"{options.Endpoint}/api/{action}?{query}";
+        return $"{options.Endpoint}/api/{action}{query}";
     }
 
     private static void AppendKeyValuePair(this StringBuilder builder, in KeyValuePair<string, string?> pair,


### PR DESCRIPTION
A simple fix for the BUG that two continuous question marks will appear in the action url.

Though it seems that the duplicated question marks could also be parsed, it may be better to remove it to avoid confusion.