### PR TITLE
feat: Optimized error messages for GET methods.

### DIFF
--- a/src/Casdoor.Client/CasdoorClient.ApplicationApi.cs
+++ b/src/Casdoor.Client/CasdoorClient.ApplicationApi.cs
@@ -53,27 +53,27 @@ public partial class CasdoorClient
     {
         var queryMap = new QueryMapBuilder().Add("id", id).QueryMap;
         var url = _options.GetActionUrl("get-application", queryMap);
-        return _httpClient.GetFromJsonAsync<CasdoorApplication>(url, cancellationToken: cancellationToken);
+        return GetFromJsonAsync<CasdoorApplication>(url, cancellationToken: cancellationToken);
     }
 
     public virtual Task<IEnumerable<CasdoorApplication>?> GetApplicationsAsync(string owner, CancellationToken cancellationToken = default)
     {
         var queryMap = new QueryMapBuilder().Add("owner", owner).QueryMap;
         var url = _options.GetActionUrl("get-applications", queryMap);
-        return _httpClient.GetFromJsonAsync<IEnumerable<CasdoorApplication>>(url, cancellationToken: cancellationToken);
+        return GetFromJsonAsync<IEnumerable<CasdoorApplication>>(url, cancellationToken: cancellationToken);
     }
 
     public virtual Task<IEnumerable<CasdoorApplication>?> GetOrganizationApplicationsAsync(string organization, CancellationToken cancellationToken = default)
     {
         var queryMap = new QueryMapBuilder().Add("organization", organization).QueryMap;
         var url = _options.GetActionUrl("get-organization-applications", queryMap);
-        return _httpClient.GetFromJsonAsync<IEnumerable<CasdoorApplication>>(url, cancellationToken: cancellationToken);
+        return GetFromJsonAsync<IEnumerable<CasdoorApplication>>(url, cancellationToken: cancellationToken);
     }
 
     public virtual Task<CasdoorApplication?> GetUserApplicationAsync(string id, CancellationToken cancellationToken = default)
     {
         var queryMap = new QueryMapBuilder().Add("id", id).QueryMap;
         var url = _options.GetActionUrl("get-user-application", queryMap);
-        return _httpClient.GetFromJsonAsync<CasdoorApplication>(url, cancellationToken: cancellationToken);
+        return GetFromJsonAsync<CasdoorApplication>(url, cancellationToken: cancellationToken);
     }
 }

--- a/src/Casdoor.Client/CasdoorClient.Internal.cs
+++ b/src/Casdoor.Client/CasdoorClient.Internal.cs
@@ -30,13 +30,7 @@ public partial class CasdoorClient
         }
         catch (JsonException e)
         {
-            stream.Seek(0, SeekOrigin.Begin);
-            var casdoorResponse = await JsonSerializer.DeserializeAsync<CasdoorResponse>(stream, cancellationToken: cancellationToken);
-            if (casdoorResponse is not null)
-            {
-                throw new CasdoorApiException(casdoorResponse.Msg, e);
-            }
-            throw;
+            throw new CasdoorApiException($"Server response cannot be deserialized as type {typeof(TValue).FullName}. Server API and SDK implementation are inconsistent.", e);
         }
         return successResult;
     }

--- a/src/Casdoor.Client/CasdoorClient.Internal.cs
+++ b/src/Casdoor.Client/CasdoorClient.Internal.cs
@@ -13,13 +13,33 @@
 // limitations under the License.
 
 using System.Net.Http.Json;
+using System.Text.Json;
 
 namespace Casdoor.Client;
 
 public partial class CasdoorClient
 {
-    internal Task<TValue?> GetFromJsonAsync<TValue>(string? requestUri, CancellationToken cancellationToken = default)
-        => _httpClient.GetFromJsonAsync<TValue>(requestUri, cancellationToken);
+    internal async Task<TValue?> GetFromJsonAsync<TValue>(string? requestUri, CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.GetAsync(requestUri, cancellationToken);
+        using var stream = await response.Content.ReadAsStreamAsync();
+        TValue? successResult;
+        try
+        {
+            successResult = await JsonSerializer.DeserializeAsync<TValue>(stream, cancellationToken: cancellationToken);
+        }
+        catch (JsonException e)
+        {
+            stream.Seek(0, SeekOrigin.Begin);
+            var casdoorResponse = await JsonSerializer.DeserializeAsync<CasdoorResponse>(stream, cancellationToken: cancellationToken);
+            if (casdoorResponse is not null)
+            {
+                throw new CasdoorApiException(casdoorResponse.Msg, e);
+            }
+            throw;
+        }
+        return successResult;
+    }
 
     internal async Task<CasdoorResponse?> PostAsJsonAsync<TValue>(string? requestUri, TValue value, CancellationToken cancellationToken = default)
     {

--- a/src/Casdoor.Client/CasdoorClient.OrganizationApi.cs
+++ b/src/Casdoor.Client/CasdoorClient.OrganizationApi.cs
@@ -50,13 +50,13 @@ public partial class CasdoorClient
     {
         var queryMap = new QueryMapBuilder().Add("id", id).QueryMap;
         var url = _options.GetActionUrl("get-organization", queryMap);
-        return _httpClient.GetFromJsonAsync<CasdoorOrganization>(url, cancellationToken: cancellationToken);
+        return GetFromJsonAsync<CasdoorOrganization>(url, cancellationToken: cancellationToken);
     }
 
     public virtual Task<IEnumerable<CasdoorOrganization>?> GetOrganizationsAsync(string owner, CancellationToken cancellationToken = default)
     {
         var queryMap = new QueryMapBuilder().Add("owner", owner).QueryMap;
         var url = _options.GetActionUrl("get-organizations", queryMap);
-        return _httpClient.GetFromJsonAsync<IEnumerable<CasdoorOrganization>>(url, cancellationToken: cancellationToken);
+        return GetFromJsonAsync<IEnumerable<CasdoorOrganization>>(url, cancellationToken: cancellationToken);
     }
 }

--- a/src/Casdoor.Client/CasdoorClient.PermissionApi.cs
+++ b/src/Casdoor.Client/CasdoorClient.PermissionApi.cs
@@ -22,13 +22,13 @@ public partial class CasdoorClient
     {
         var queryMap = new QueryMapBuilder().Add("owner", _options.OrganizationName).QueryMap;
         string url = _options.GetActionUrl("get-permissions", queryMap);
-        return _httpClient.GetFromJsonAsync<IEnumerable<CasdoorPermission>>(url, cancellationToken);
+        return GetFromJsonAsync<IEnumerable<CasdoorPermission>>(url, cancellationToken);
     }
 
     public virtual Task<CasdoorResponse<IEnumerable<CasdoorPermission>>?> GetPermissionsByRoleAsync(string name, CancellationToken cancellationToken = default)
     {
         var queryMap = new QueryMapBuilder().Add("id", $"{_options.OrganizationName}/{name}").QueryMap;
         string url = _options.GetActionUrl("get-permissions-by-role", queryMap);
-        return _httpClient.GetFromJsonAsync<CasdoorResponse<IEnumerable<CasdoorPermission>>>(url, cancellationToken);
+        return GetFromJsonAsync<CasdoorResponse<IEnumerable<CasdoorPermission>>>(url, cancellationToken);
     }
 }

--- a/src/Casdoor.Client/CasdoorClient.ProviderApi.cs
+++ b/src/Casdoor.Client/CasdoorClient.ProviderApi.cs
@@ -50,19 +50,19 @@ public partial class CasdoorClient
     {
         var queryMap = new QueryMapBuilder().Add("id", id).QueryMap;
         var url = _options.GetActionUrl("get-provider", queryMap);
-        return _httpClient.GetFromJsonAsync<CasdoorProvider>(url, cancellationToken: cancellationToken);
+        return GetFromJsonAsync<CasdoorProvider>(url, cancellationToken: cancellationToken);
     }
 
     public virtual Task<IEnumerable<CasdoorProvider>?> GetProvidersAsync(string owner, CancellationToken cancellationToken = default)
     {
         var queryMap = new QueryMapBuilder().Add("owner", owner).QueryMap;
         var url = _options.GetActionUrl("get-providers", queryMap);
-        return _httpClient.GetFromJsonAsync<IEnumerable<CasdoorProvider>>(url, cancellationToken: cancellationToken);
+        return GetFromJsonAsync<IEnumerable<CasdoorProvider>>(url, cancellationToken: cancellationToken);
     }
 
     public virtual Task<IEnumerable<CasdoorProvider>?> GetGlobalProvidersAsync(CancellationToken cancellationToken = default)
     {
         var url = _options.GetActionUrl("get-global-providers");
-        return _httpClient.GetFromJsonAsync<IEnumerable<CasdoorProvider>>(url, cancellationToken: cancellationToken);
+        return GetFromJsonAsync<IEnumerable<CasdoorProvider>>(url, cancellationToken: cancellationToken);
     }
 }

--- a/src/Casdoor.Client/CasdoorClient.RoleApi.cs
+++ b/src/Casdoor.Client/CasdoorClient.RoleApi.cs
@@ -22,6 +22,6 @@ public partial class CasdoorClient
     {
         var queryMap = new QueryMapBuilder().Add("owner", _options.OrganizationName).QueryMap;
         string url = _options.GetActionUrl("get-roles", queryMap);
-        return _httpClient.GetFromJsonAsync<IEnumerable<CasdoorRole>>(url, cancellationToken);
+        return GetFromJsonAsync<IEnumerable<CasdoorRole>>(url, cancellationToken);
     }
 }

--- a/src/Casdoor.Client/CasdoorClient.UserApi.cs
+++ b/src/Casdoor.Client/CasdoorClient.UserApi.cs
@@ -46,7 +46,7 @@ public partial class CasdoorClient
     {
         var queryMap = new QueryMapBuilder().Add("id", id).QueryMap;
         string url = _options.GetActionUrl("get-user", queryMap);
-        return _httpClient.GetFromJsonAsync<CasdoorUser>(url, cancellationToken);
+        return GetFromJsonAsync<CasdoorUser>(url, cancellationToken);
     }
 
     public virtual Task<CasdoorUser?> GetUserByEmailAsync(string email, CancellationToken cancellationToken = default)

--- a/src/Casdoor.Client/CasdoorClient.UserApi.cs
+++ b/src/Casdoor.Client/CasdoorClient.UserApi.cs
@@ -22,7 +22,7 @@ public partial class CasdoorClient
     {
         var queryMap = new QueryMapBuilder().Add("owner", _options.OrganizationName).QueryMap;
         string url = _options.GetActionUrl("get-users", queryMap);
-        return _httpClient.GetFromJsonAsync<IEnumerable<CasdoorUser>>(url, cancellationToken);
+        return GetFromJsonAsync<IEnumerable<CasdoorUser>>(url, cancellationToken);
     }
 
     public virtual Task<IEnumerable<CasdoorUser>?> GetSortedUsersAsync(string sorter, int limit, CancellationToken cancellationToken = default)
@@ -32,14 +32,14 @@ public partial class CasdoorClient
             .Add("sorter", sorter)
             .Add("limit", limit.ToString()).QueryMap;
         string url = _options.GetActionUrl("get-sorted-users", queryMap);
-        return _httpClient.GetFromJsonAsync<IEnumerable<CasdoorUser>>(url, cancellationToken);
+        return GetFromJsonAsync<IEnumerable<CasdoorUser>>(url, cancellationToken);
     }
 
     public virtual Task<CasdoorUser?> GetUserAsync(string name, CancellationToken cancellationToken = default)
     {
         var queryMap = new QueryMapBuilder().Add("id", $"{_options.OrganizationName}/{name}").QueryMap;
         string url = _options.GetActionUrl("get-user", queryMap);
-        return _httpClient.GetFromJsonAsync<CasdoorUser>(url, cancellationToken);
+        return GetFromJsonAsync<CasdoorUser>(url, cancellationToken);
     }
 
     public virtual Task<CasdoorUser?> GetUseByIdrAsync(string id, CancellationToken cancellationToken = default)
@@ -55,7 +55,7 @@ public partial class CasdoorClient
             .Add("owner", _options.OrganizationName)
             .Add("email", email).QueryMap;
         string url = _options.GetActionUrl("get-user", queryMap);
-        return _httpClient.GetFromJsonAsync<CasdoorUser>(url, cancellationToken);
+        return GetFromJsonAsync<CasdoorUser>(url, cancellationToken);
     }
 
     public virtual Task<CasdoorResponse?> AddUserAsync(CasdoorUser user, CancellationToken cancellationToken = default)


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor-dotnet-sdk/issues/38

As [#38 ](https://github.com/casdoor/casdoor-dotnet-sdk/issues/38), improved the exception that throws a json exception when the GET method returns a json with "status": "error", now the exception message is the value of the "msg" field.