### PR TITLE
fix: made multiFactorAuths a list of CasdoorMfaProps objects instead of a single object

### DIFF
--- a/src/Casdoor.Client/Models/CasdoorUser.cs
+++ b/src/Casdoor.Client/Models/CasdoorUser.cs
@@ -425,7 +425,7 @@ public class CasdoorUser
     public bool? MfaEmailEnabled { get; set; }
 
     [JsonPropertyName("multiFactorAuths")]
-    public CasdoorMfaProps? MultiFactorAuths { get; set; }
+    public IEnumerable<CasdoorMfaProps>? MultiFactorAuths { get; set; }
 
     [JsonPropertyName("ldap")]
     public string? Ldap { get; set; }


### PR DESCRIPTION
Hi! Fixed my mistake making CasdoorUser.MultiFactorAuths a single object of CasdoorMfaProps class instead of list IEnumerable<CasdoorMfaProps>

Sorry for the inconvenience :(