### PR TITLE
fix: fix typo in Visible JsonProperty name for CasdoorAccountItem

### DIFF
--- a/src/Casdoor.Client/Models/CasdoorOrganization.cs
+++ b/src/Casdoor.Client/Models/CasdoorOrganization.cs
@@ -31,7 +31,7 @@ public class CasdoorAccountItem
     [JsonPropertyName("name")]
     public string? Name { get; set; }
 
-    [JsonPropertyName("visibles")]
+    [JsonPropertyName("visible")]
     public bool? Visible { get; set; }
 
     [JsonPropertyName("viewRule")]


### PR DESCRIPTION
Hi there! Fixed typo in Visible JsonProperty name for CasdoorAccountItem class