### PR TITLE
feat: add all missing APIs for all objects: group, model, adapter, enforcer, etc.

### DIFF
--- a/src/Casdoor.Client/Abstractions/ICasdoorAccountClient.cs
+++ b/src/Casdoor.Client/Abstractions/ICasdoorAccountClient.cs
@@ -29,4 +29,12 @@ public interface ICasdoorAccountClient
     public Task<CasdoorLdapUsers?> GetLdapUsersAsync(string owner, string id, CancellationToken cancellationToken = default);
 
     public Task<CasdoorResponse?> UpdateLdapAsync(string id, CasdoorLdap ldap, CancellationToken cancellationToken = default);
+
+    public Task<CasdoorAccount?> GetAccountAsync(CancellationToken cancellationToken = default);
+
+    public Task<CasdoorResponse?> ResetEmailOrPhoneAsync(CasdoorResetEmailOrPhoneForm casdoorResetEmailOrPhoneForm, CancellationToken cancellationToken = default);
+
+    public Task<CasdoorLaravelResponse?> User(CancellationToken cancellationToken = default);
+
+    public Task<CasdoorUserInfo?> UserInfo(CancellationToken cancellationToken = default);
 }

--- a/src/Casdoor.Client/Abstractions/ICasdoorAdpaterClient.cs
+++ b/src/Casdoor.Client/Abstractions/ICasdoorAdpaterClient.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Casdoor.Client;
+
+namespace Casdoor.Client;
+
+public interface ICasdoorAdapterClient
+{
+    public Task<CasdoorResponse?> AddAdapterAsync(CasdoorAdapter adapter, CancellationToken cancellationToken = default);
+    public Task<CasdoorResponse?> UpdateAdapterAsync(CasdoorAdapter adapter, IEnumerable<string> propertyNames, CancellationToken cancellationToken = default);
+    public Task<CasdoorResponse?> UpdateAdapterColumnsAsync(CasdoorAdapter adapter, IEnumerable<string>? columns, CancellationToken cancellationToken = default);
+    public Task<CasdoorResponse?> DeleteAdapterAsync(string owner, string name, CancellationToken cancellationToken = default);
+    public Task<CasdoorAdapter?> GetAdapterAsync(string owner, string name, CancellationToken cancellationToken = default);
+    public Task<IEnumerable<CasdoorAdapter>?> GetAdaptersAsync(string owner, CancellationToken cancellationToken = default);
+    public Task<IEnumerable<CasdoorAdapter>?> GetPaginationAdaptersAsync(string owner, int pageSize, int p,
+        List<KeyValuePair<string, string?>>? queryMap, CancellationToken cancellationToken = default);
+}

--- a/src/Casdoor.Client/Abstractions/ICasdoorCertClient.cs
+++ b/src/Casdoor.Client/Abstractions/ICasdoorCertClient.cs
@@ -1,0 +1,25 @@
+﻿// Copyright 2024 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Casdoor.Client;
+
+public interface ICasdoorCertClient
+{
+    public Task<CasdoorResponse?> AddCertAsync(CasdoorCert cert, CancellationToken cancellationToken = default);
+    public Task<CasdoorResponse?> UpdateCertAsync(CasdoorCert cert, CancellationToken cancellationToken = default);
+    public Task<CasdoorResponse?> DeleteCertAsync(string name, CancellationToken cancellationToken = default);
+    public Task<CasdoorCert?> GetCertAsync(string name, CancellationToken cancellationToken = default);
+    public Task<IEnumerable<CasdoorCert>?> GetCertsAsync(CancellationToken cancellationToken = default);
+    public Task<IEnumerable<CasdoorCert>?> GetGlobalCertsAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Casdoor.Client/Abstractions/ICasdoorClient.cs
+++ b/src/Casdoor.Client/Abstractions/ICasdoorClient.cs
@@ -15,9 +15,11 @@
 namespace Casdoor.Client;
 
 public interface ICasdoorClient :
-    ICasdoorUserClient, ICasdoorTokenClient, ICasdoorResourceClient, ICasdoorServiceClient,
+    ICasdoorUserClient, ICasdoorTokenClient, ICasdoorResourceClient, ICasdoorServiceClient, ICasdoorWebhookClient,
     ICasdoorApplicationClient, ICasdoorOrganizationClient, ICasdoorProviderClient, ICasdoorAccountClient, ICasdoorModelClient,
-    ICasdoorEnforcerClient, ICasdoorGroupClient, ICasdoorPlanClient
+    ICasdoorEnforcerClient, ICasdoorGroupClient, ICasdoorPlanClient, ICasdoorSyncerClient, ICasdoorSubscriptionClient, ICasdoorPermissionClient,
+    ICasdoorAdapterClient, ICasdoorCertClient, ICasdoorPaymentClient, ICasdoorPricingClient, ICasdoorProductClient, ICasdoorSessionClient,
+    ICasdoorRoleClient, ICasdoorRecordClient
 {
 
 }

--- a/src/Casdoor.Client/Abstractions/ICasdoorOrganizationClient.cs
+++ b/src/Casdoor.Client/Abstractions/ICasdoorOrganizationClient.cs
@@ -21,4 +21,5 @@ public interface ICasdoorOrganizationClient
     public Task<CasdoorResponse?> UpdateOrganizationAsync(string id, CasdoorOrganization newOrganization, CancellationToken cancellationToken = default);
     public Task<CasdoorOrganization?> GetOrganizationAsync(string id, CancellationToken cancellationToken = default);
     public Task<IEnumerable<CasdoorOrganization>?> GetOrganizationsAsync(string owner, CancellationToken cancellationToken = default);
+    public Task<IEnumerable<CasdoorOrganization>?> GetOrganizationNamesAsync(string owner, CancellationToken cancellationToken = default);
 }

--- a/src/Casdoor.Client/Abstractions/ICasdoorPaymentClient.cs
+++ b/src/Casdoor.Client/Abstractions/ICasdoorPaymentClient.cs
@@ -1,0 +1,29 @@
+﻿// Copyright 2024 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Casdoor.Client;
+
+public interface ICasdoorPaymentClient
+{
+    public Task<CasdoorResponse?> AddPaymentAsync(CasdoorPayment payment, CancellationToken cancellationToken = default);
+    public Task<CasdoorResponse?> UpdatePaymentAsync(CasdoorPayment payment, CancellationToken cancellationToken = default);
+    public Task<CasdoorResponse?> NotifyPaymentAsync(CasdoorPayment payment, CancellationToken cancellationToken = default);
+    public Task<CasdoorResponse?> InvoicePaymentAsync(CasdoorPayment payment, CancellationToken cancellationToken = default);
+    public Task<CasdoorResponse?> DeletePaymentAsync(CasdoorPayment payment, CancellationToken cancellationToken = default);
+    public Task<CasdoorPayment?> GetPaymentAsync(string name, CancellationToken cancellationToken = default);
+    public Task<IEnumerable<CasdoorPayment>?> GetUserPaymentsAsync(string userName,CancellationToken cancellationToken = default);
+    public Task<IEnumerable<CasdoorPayment>?> GetPaymentsAsync(CancellationToken cancellationToken = default);
+    public Task<IEnumerable<CasdoorPayment>?> GetPaginationPaymentsAsync(int pageSize, int p,
+        List<KeyValuePair<string, string?>>? queryMap, CancellationToken cancellationToken = default);
+}

--- a/src/Casdoor.Client/Abstractions/ICasdoorPermissionClient.cs
+++ b/src/Casdoor.Client/Abstractions/ICasdoorPermissionClient.cs
@@ -1,0 +1,28 @@
+﻿// Copyright 2024 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Casdoor.Client;
+
+public interface ICasdoorPermissionClient
+{
+    public Task<CasdoorResponse?> AddPermissionAsync(CasdoorPermission permission, CancellationToken cancellationToken = default);
+    public Task<CasdoorResponse?> DeletePermissionAsync(CasdoorPermission permission, CancellationToken cancellationToken = default);
+    public Task<CasdoorResponse?> UpdatePermissionAsync(CasdoorPermission permission, string permissionId,
+        CancellationToken cancellationToken = default);
+    public Task<CasdoorResponse?> UpdatePermissionAsyncForCoulums(CasdoorPermission permission, IEnumerable<string>? columns,
+        CancellationToken cancellationToken = default);
+    public Task<CasdoorPermission?> GetPermissionAsync(string id, CancellationToken cancellationToken = default);
+    public Task<IEnumerable<CasdoorPermission>?> GetPermissionsAsync(string owner, CancellationToken cancellationToken = default);
+    public Task<IEnumerable<CasdoorPermission>?> GetPermissionsByRoleAsync(string name, string? owner = null, CancellationToken cancellationToken = default);
+}

--- a/src/Casdoor.Client/Abstractions/ICasdoorPricingClient.cs
+++ b/src/Casdoor.Client/Abstractions/ICasdoorPricingClient.cs
@@ -1,0 +1,26 @@
+﻿// Copyright 2024 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Casdoor.Client;
+
+public interface ICasdoorPricingClient
+{
+    public Task<CasdoorResponse?> AddPricingAsync(CasdoorPricing pricing, CancellationToken cancellationToken = default);
+    public Task<CasdoorResponse?> UpdatePricingAsync(CasdoorPricing pricing, CancellationToken cancellationToken = default);
+    public Task<CasdoorResponse?> DeletePricingAsync(CasdoorPricing pricing, CancellationToken cancellationToken = default);
+    public Task<CasdoorPricing?> GetPricingAsync(string name, CancellationToken cancellationToken = default);
+    public Task<IEnumerable<CasdoorPricing>?> GetPricingsAsync(CancellationToken cancellationToken = default);
+    public Task<IEnumerable<CasdoorPricing>?> GetPaginationPricingsAsync(int pageSize, int p,
+        List<KeyValuePair<string, string?>>? queryMap, CancellationToken cancellationToken = default);
+}

--- a/src/Casdoor.Client/Abstractions/ICasdoorProductClient.cs
+++ b/src/Casdoor.Client/Abstractions/ICasdoorProductClient.cs
@@ -1,0 +1,27 @@
+﻿// Copyright 2024 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Casdoor.Client;
+public interface ICasdoorProductClient
+{
+    public Task<CasdoorResponse?> AddProductAsync(CasdoorProduct product, CancellationToken cancellationToken = default);
+    public Task<CasdoorResponse?> UpdateProductAsync(CasdoorProduct product, CancellationToken cancellationToken = default);
+    public Task<CasdoorResponse?> DeleteProductAsync(CasdoorProduct product, CancellationToken cancellationToken = default);
+    public Task<CasdoorProduct?> GetProductAsync(string name, CancellationToken cancellationToken = default);
+    public Task<IEnumerable<CasdoorProduct>?> GetProductsAsync(CancellationToken cancellationToken = default);
+    public Task<IEnumerable<CasdoorProduct>?> GetPaginationProductsAsync(int pageSize, int p,
+        List<KeyValuePair<string, string?>>? queryMap, CancellationToken cancellationToken = default);
+
+    public Task<CasdoorResponse?> BuyProductAsync(string name, string providerName, CancellationToken cancellationToken = default);
+}

--- a/src/Casdoor.Client/Abstractions/ICasdoorRecordClient.cs
+++ b/src/Casdoor.Client/Abstractions/ICasdoorRecordClient.cs
@@ -1,0 +1,26 @@
+﻿// Copyright 2024 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Casdoor.Client;
+
+public interface ICasdoorRecordClient
+{
+    public Task<CasdoorResponse?> AddRecordAsync(CasdoorRecord record, CancellationToken cancellationToken = default);
+    public Task<CasdoorResponse?> UpdateRecordAsync(CasdoorRecord record, CancellationToken cancellationToken = default);
+    public Task<CasdoorResponse?> DeleteRecordAsync(CasdoorRecord record, CancellationToken cancellationToken = default);
+    public Task<CasdoorRecord?> GetRecordAsync(string name, CancellationToken cancellationToken = default);
+    public Task<IEnumerable<CasdoorRecord>?> GetRecordsAsync(CancellationToken cancellationToken = default);
+    public Task<IEnumerable<CasdoorRecord>?> GetPaginationRecordsAsync(int pageSize, int p,
+        List<KeyValuePair<string, string?>>? queryMap, CancellationToken cancellationToken = default);
+}

--- a/src/Casdoor.Client/Abstractions/ICasdoorResourceClient.cs
+++ b/src/Casdoor.Client/Abstractions/ICasdoorResourceClient.cs
@@ -20,4 +20,13 @@ public interface ICasdoorResourceClient
         Stream fileStream, string createdTime = "", string description = "", CancellationToken cancellationToken = default);
 
     public Task<CasdoorResponse?> DeleteResourceAsync(string name, CancellationToken cancellationToken = default);
+
+    public Task<CasdoorResponse?> AddResourceAsync(CasdoorUserResource casdoorUserResource, CancellationToken cancellationToken = default);
+
+    public Task<CasdoorUserResource?> GetResourceAsync(string name, CancellationToken cancellationToken = default);
+
+    public Task<IEnumerable<CasdoorUserResource>?> GetResourcesAsync(string owner, string user,
+        string field, string value, string sortField, string sortOrder, CancellationToken cancellationToken = default);
+
+    public Task<IEnumerable<CasdoorUserResource>?> GetPaginationResourcesAsync(string owner, string user, int pageSize, int p, string field, string value, string sortField, string sortOrder, CancellationToken cancellationToken = default);
 }

--- a/src/Casdoor.Client/Abstractions/ICasdoorRoleClient.cs
+++ b/src/Casdoor.Client/Abstractions/ICasdoorRoleClient.cs
@@ -1,0 +1,26 @@
+﻿// Copyright 2024 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Casdoor.Client;
+
+public interface ICasdoorRoleClient
+{
+    public Task<CasdoorResponse?> AddRoleAsync(CasdoorRole role, CancellationToken cancellationToken = default);
+    public Task<CasdoorResponse?> UpdateRoleAsync(CasdoorRole role, string name, string? owner = null,
+        CancellationToken cancellationToken = default);
+    public Task<CasdoorResponse?> DeleteRoleAsync(CasdoorRole role, CancellationToken cancellationToken = default);
+    public Task<CasdoorRole?> GetRoleAsync(string name, string? owner = null,
+        CancellationToken cancellationToken = default);
+    public Task<IEnumerable<CasdoorRole>?> GetRolesAsync(string? owner = null, CancellationToken cancellationToken = default);
+}

--- a/src/Casdoor.Client/Abstractions/ICasdoorServiceClient.cs
+++ b/src/Casdoor.Client/Abstractions/ICasdoorServiceClient.cs
@@ -20,4 +20,6 @@ public interface ICasdoorServiceClient
 
     public Task<CasdoorResponse?> SendEmailAsync(string title, string content, string sender,
         IEnumerable<string> receivers, CancellationToken cancellationToken = default);
+
+    public Task<CasdoorResponse?> SendNotification(string content, CancellationToken cancellationToken = default);
 }

--- a/src/Casdoor.Client/Abstractions/ICasdoorSessionClient.cs
+++ b/src/Casdoor.Client/Abstractions/ICasdoorSessionClient.cs
@@ -1,0 +1,27 @@
+﻿// Copyright 2024 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Casdoor.Client;
+
+public interface ICasdoorSessionClient
+{
+    public Task<CasdoorResponse?> AddSessionAsync(CasdoorSession session, CancellationToken cancellationToken = default);
+    public Task<CasdoorResponse?> UpdateSessionAsync(CasdoorSession session, CancellationToken cancellationToken = default);
+    public Task<CasdoorResponse?> UpdateSessionForColumnsAsync(CasdoorSession session,IEnumerable<string> columns, CancellationToken cancellationToken = default);
+    public Task<CasdoorResponse?> DeleteSessionAsync(CasdoorSession session, CancellationToken cancellationToken = default);
+    public Task<CasdoorSession?> GetSessionAsync(string name, string application, CancellationToken cancellationToken = default);
+    public Task<IEnumerable<CasdoorSession>?> GetSessionsAsync(CancellationToken cancellationToken = default);
+    public Task<IEnumerable<CasdoorSession>?> GetPaginationSessionsAsync(int pageSize, int p,
+        List<KeyValuePair<string, string?>>? queryMap, CancellationToken cancellationToken = default);
+}

--- a/src/Casdoor.Client/Abstractions/ICasdoorSubscriptionClient.cs
+++ b/src/Casdoor.Client/Abstractions/ICasdoorSubscriptionClient.cs
@@ -1,0 +1,32 @@
+﻿// Copyright 2024 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Casdoor.Client;
+
+public interface ICasdoorSubscriptionClient
+{
+    public Task<CasdoorResponse?> AddSubscriptionAsync(CasdoorSubscription casdoorSubscription, CancellationToken cancellationToken = default);
+
+    public Task<CasdoorResponse?> DeleteSubscriptionAsync(CasdoorSubscription casdoorSubscription, CancellationToken cancellationToken = default);
+
+    public Task<CasdoorSubscription?> GetSubscriptionAsync(string owner, string name, CancellationToken cancellationToken = default);
+    public Task<IEnumerable<CasdoorSubscription>?> GetPaginationSubscriptions(string owner, int p, int pageSize,
+        List<KeyValuePair<string, string?>> queryMap, CancellationToken cancellationToken = default);
+    public Task<IEnumerable<CasdoorSubscription>?> GetSubscriptionsAsync(string owner, CancellationToken cancellationToken = default);
+
+    public Task<CasdoorResponse?> UpdateSubscriptionAsync(CasdoorSubscription casdoorSubscription, CancellationToken cancellationToken = default);
+}
+  
+ 
+

--- a/src/Casdoor.Client/Abstractions/ICasdoorSyncerClient.cs
+++ b/src/Casdoor.Client/Abstractions/ICasdoorSyncerClient.cs
@@ -1,0 +1,30 @@
+﻿// Copyright 2024 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Casdoor.Client;
+
+public interface ICasdoorSyncerClient
+{
+    public Task<CasdoorResponse?> AddSyncerAsync(CasdoorSyncer casdoorSyncer, CancellationToken cancellationToken = default);
+
+    public Task<CasdoorResponse?> DeleteSyncerAsync(CasdoorSyncer casdoorSyncer, CancellationToken cancellationToken = default);
+
+    public Task<CasdoorSyncer?> GetSyncerAsync(string owner, string name, CancellationToken cancellationToken = default);
+
+    public Task<IEnumerable<CasdoorSyncer>?> GetSyncersAsync(string owner, CancellationToken cancellationToken = default);
+
+    public Task<CasdoorResponse?> RunSyncerAsync(CasdoorSyncer casdoorSyncer, CancellationToken cancellationToken = default);
+
+    public Task<CasdoorResponse?> UpdateSyncerAsync(CasdoorSyncer casdoorSyncer, CancellationToken cancellationToken = default);
+}

--- a/src/Casdoor.Client/Abstractions/ICasdoorTokenClient.cs
+++ b/src/Casdoor.Client/Abstractions/ICasdoorTokenClient.cs
@@ -22,4 +22,14 @@ public interface ICasdoorTokenClient
     public Task<TokenResponse> RequestPasswordTokenAsync(string username, string password, CancellationToken cancellationToken = default);
     public Task<TokenResponse> RequestAuthorizationCodeTokenAsync(string code, string redirectUri, string codeVerifier = "", CancellationToken cancellationToken = default);
     public Task<TokenResponse> RequestRefreshTokenAsync(string refreshToken, CancellationToken cancellationToken = default);
+    public Task<CasdoorResponse?> AddTokenAsync(CasdoorToken casdoorToken, CancellationToken cancellationToken = default);
+    public Task<CasdoorResponse?> DeleteTokenAsync(CasdoorToken casdoorToken, CancellationToken cancellationToken = default);
+    public Task<CasdoorResponse?> GetCaptchaStatusAsync(string id, CancellationToken cancellationToken = default);
+    public Task<CasdoorToken?> GetTokenAsync(string owner, string name, CancellationToken cancellationToken = default);
+    public Task<IEnumerable<CasdoorToken>?> GetTokensAsync(string owner,CancellationToken cancellationToken = default);
+    public Task<IEnumerable<CasdoorToken>?> GetPaginationTokensAsync(string owner, int pageSize, int p,
+        List<KeyValuePair<string, string?>>? queryMap, CancellationToken cancellationToken = default);
+    public Task<CasdoorResponse?> UpdateTokenAsync(CasdoorToken casdoorToken, IEnumerable<string> propertyNames, CancellationToken cancellationToken = default);
+    public Task<CasdoorResponse?> UpdateTokenColumnsAsync(CasdoorToken token, IEnumerable<string>? columns, CancellationToken cancellationToken = default);
+
 }

--- a/src/Casdoor.Client/Abstractions/ICasdoorUserClient.cs
+++ b/src/Casdoor.Client/Abstractions/ICasdoorUserClient.cs
@@ -20,10 +20,14 @@ public interface ICasdoorUserClient
     public Task<IEnumerable<CasdoorUser>?> GetSortedUsersAsync(string sorter, int limit, string? owner = null, CancellationToken cancellationToken = default);
     public Task<CasdoorUser?> GetUserAsync(string name, string? owner = null, CancellationToken cancellationToken = default);
     public Task<CasdoorUser?> GetUserByEmailAsync(string email, string? owner = null, CancellationToken cancellationToken = default);
+    public Task<CasdoorUser?> GetUserByPhoneAsync(string phone, string? owner = null, CancellationToken cancellationToken = default);
     public Task<CasdoorResponse?> AddUserAsync(CasdoorUser user, CancellationToken cancellationToken = default);
     public Task<CasdoorResponse?> UpdateUserAsync(CasdoorUser user, IEnumerable<string> propertyNames, CancellationToken cancellationToken = default );
+    public Task<CasdoorResponse?> UpdateUserByIdAsync(string userId, CasdoorUser user, CancellationToken cancellationToken);
+    public Task<CasdoorResponse?> UpdateUserForColumns(CasdoorUser user, IEnumerable<string> columns, CancellationToken cancellationToken);
     public Task<CasdoorResponse?> UpdateUserForbiddenFlagAsync(CasdoorUser user, CancellationToken cancellationToken = default);
     public Task<CasdoorResponse?> UpdateUserDeletedFlagAsync(CasdoorUser user, CancellationToken cancellationToken = default);
     public Task<CasdoorResponse?> DeleteUserAsync(string name, CancellationToken cancellationToken = default);
     public Task<CasdoorResponse?> CheckUserPasswordAsync(string name, CancellationToken cancellationToken = default);
+    public Task<int?> GetUserCount(string owner, int isOnline, CancellationToken cancellationToken = default);
 }

--- a/src/Casdoor.Client/Abstractions/ICasdoorWebhookClient.cs
+++ b/src/Casdoor.Client/Abstractions/ICasdoorWebhookClient.cs
@@ -1,0 +1,24 @@
+﻿// Copyright 2024 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Casdoor.Client;
+
+public interface ICasdoorWebhookClient
+{
+    public Task<CasdoorResponse?> AddWebhookAsync(CasdoorWebhook webhook, CancellationToken cancellationToken = default);
+    public Task<CasdoorResponse?> DeleteWebhookAsync(CasdoorWebhook webhook, CancellationToken cancellationToken = default);
+    public Task<CasdoorWebhook?> GetWebhookAsync(string owner, string name, CancellationToken cancellationToken = default);
+    public Task<IEnumerable<CasdoorWebhook>?> GetWebhooksAsync(string owner, CancellationToken cancellationToken = default);
+    public Task<CasdoorResponse?> UpdateWebhookAsync(CasdoorWebhook webhook, CancellationToken cancellationToken = default);
+}

--- a/src/Casdoor.Client/Casdoor.Client.csproj
+++ b/src/Casdoor.Client/Casdoor.Client.csproj
@@ -50,7 +50,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.16.0" />
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.34.0" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.16.0" />
     <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
   </ItemGroup>

--- a/src/Casdoor.Client/CasdoorClient.AccountApi.cs
+++ b/src/Casdoor.Client/CasdoorClient.AccountApi.cs
@@ -84,15 +84,45 @@ public partial class CasdoorClient
     {
         var queryMap = new QueryMapBuilder().Add("id", $"{owner}/{id}").QueryMap;
         var url = _options.GetActionUrl("get-ldap-users", queryMap);
-        var result = await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken: cancellationToken);
+        var result = await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken);
         return result.DeserializeData<CasdoorLdapUsers?>();
     }
 
     public virtual Task<CasdoorResponse?> SyncLdapUsersAsync(string owner, string id, IEnumerable<CasdoorLdapUser> users, CancellationToken cancellationToken = default)
     {
-         var queryMap = new QueryMapBuilder().Add("id", $"{owner}/{id}").QueryMap;
+        var queryMap = new QueryMapBuilder().Add("id", $"{owner}/{id}").QueryMap;
 
         var url = _options.GetActionUrl("sync-ldap-users", queryMap);
         return PostAsJsonAsync(url, users, cancellationToken);
+    }
+
+    public virtual async Task<CasdoorAccount?> GetAccountAsync(CancellationToken cancellationToken = default)
+    {
+        var url = _options.GetActionUrl("get-account");
+        var result = await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken: cancellationToken);
+
+        var casdoorUser = result.DeserializeData<CasdoorUser?>();
+        var casdoorOrganization = result.DeserializeData2<CasdoorOrganization?>();
+
+        var casdoorAccount = new CasdoorAccount(casdoorUser, casdoorOrganization);
+        return casdoorAccount;
+    }
+
+    public virtual Task<CasdoorResponse?> ResetEmailOrPhoneAsync (CasdoorResetEmailOrPhoneForm casdoorResetEmailOrPhoneForm, CancellationToken cancellationToken = default)
+    {
+        var url = _options.GetActionUrl("reset-email-or-phone");
+        return PostAsJsonAsync(url, casdoorResetEmailOrPhoneForm, cancellationToken);
+    }
+
+    public virtual async Task<CasdoorLaravelResponse?> User(CancellationToken cancellationToken = default)
+    {
+        var url = _options.GetActionUrl("user");
+        return await _httpClient.GetFromJsonAsync<CasdoorLaravelResponse?>(url, cancellationToken: cancellationToken);
+    }
+
+    public virtual async Task<CasdoorUserInfo?> UserInfo(CancellationToken cancellationToken = default)
+    {
+        var url = _options.GetActionUrl("userinfo");
+        return await _httpClient.GetFromJsonAsync<CasdoorUserInfo?>(url, cancellationToken: cancellationToken);
     }
 }

--- a/src/Casdoor.Client/CasdoorClient.AdapterApi.cs
+++ b/src/Casdoor.Client/CasdoorClient.AdapterApi.cs
@@ -1,0 +1,89 @@
+﻿// Copyright 2024 The Casdoor Authors.All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Runtime.CompilerServices;
+
+namespace Casdoor.Client;
+
+public partial class CasdoorClient
+{
+
+    public virtual Task<CasdoorResponse?> AddAdapterAsync(CasdoorAdapter casdoorUserAdapter,
+        CancellationToken cancellationToken = default)
+    {
+        string url = _options.GetActionUrl("add-adapter");
+        return PostAsJsonAsync(url, casdoorUserAdapter, cancellationToken);
+    }
+
+    public virtual Task<CasdoorResponse?> DeleteAdapterAsync(string owner, string name, CancellationToken cancellationToken = default)
+    {
+        CasdoorAdapter adapter = new() { Owner = owner, Name = name };
+        var url = _options.GetActionUrl("delete-adapter");
+        return PostAsJsonAsync(url, adapter, cancellationToken);
+    }
+
+    public virtual async Task<CasdoorAdapter?> GetAdapterAsync(string owner,string name, CancellationToken cancellationToken = default)
+    {
+        var queryMap = new QueryMapBuilder()
+            .Add("id", $"{owner}/{name}").QueryMap;
+        string url = _options.GetActionUrl("get-adapter", queryMap);
+        var result = await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken: cancellationToken);
+        return result.DeserializeData<CasdoorAdapter?>();
+    }
+
+    public virtual async Task<IEnumerable<CasdoorAdapter>?> GetAdaptersAsync(string owner, CancellationToken cancellationToken = default)
+    {
+        var queryMap = new QueryMapBuilder()
+            .Add("owner", owner).QueryMap;
+        string url = _options.GetActionUrl("get-adapters", queryMap);
+        var result = await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken: cancellationToken);
+        return result.DeserializeData<IEnumerable<CasdoorAdapter>?>();
+    }
+
+    public virtual async Task<IEnumerable<CasdoorAdapter>?> GetPaginationAdaptersAsync(string owner, int pageSize, int p,
+        List<KeyValuePair<string, string?>>? queryMap, CancellationToken cancellationToken = default)
+    {
+        queryMap ??= new List<KeyValuePair<string, string?>>();
+        queryMap.Add(new KeyValuePair<string, string?>("owner", owner));
+        queryMap.Add(new KeyValuePair<string, string?>("pageSize", pageSize.ToString()));
+        queryMap.Add(new KeyValuePair<string, string?>("p", p.ToString()));
+
+        string url = _options.GetActionUrl("get-adapters", queryMap);
+        var result = await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken: cancellationToken);
+        return result.DeserializeData<IEnumerable<CasdoorAdapter>?>();
+    }
+
+    public virtual Task<CasdoorResponse?> UpdateAdapterAsync(CasdoorAdapter adapter, IEnumerable<string> propertyNames, CancellationToken cancellationToken = default)
+        => ModifyAdapterAsync("update-adapter", adapter, propertyNames, cancellationToken: cancellationToken);
+
+    public virtual Task<CasdoorResponse?> UpdateAdapterColumnsAsync(CasdoorAdapter adapter, IEnumerable<string>? columns, CancellationToken cancellationToken = default)
+        => ModifyAdapterAsync("update-adapter", adapter, columns, cancellationToken: cancellationToken);
+
+    private Task<CasdoorResponse?> ModifyAdapterAsync(string action, CasdoorAdapter adapter, IEnumerable<string>? columns, string? owner = null, CancellationToken cancellationToken = default)
+    {
+        var queryMapBuilder = new QueryMapBuilder().Add("id", $"{adapter.Owner}/{adapter.Name}");
+
+        string columnsValue = string.Join(",", columns ?? Array.Empty<string>());
+
+        if (!string.IsNullOrEmpty(columnsValue))
+        {
+            queryMapBuilder.Add("columns", columnsValue);
+        }
+
+        string url = _options.GetActionUrl(action, queryMapBuilder.QueryMap);
+        return PostAsJsonAsync(url, adapter, cancellationToken);
+    }
+}

--- a/src/Casdoor.Client/CasdoorClient.AdapterApi.cs
+++ b/src/Casdoor.Client/CasdoorClient.AdapterApi.cs
@@ -21,8 +21,7 @@ namespace Casdoor.Client;
 public partial class CasdoorClient
 {
 
-    public virtual Task<CasdoorResponse?> AddAdapterAsync(CasdoorAdapter casdoorUserAdapter,
-        CancellationToken cancellationToken = default)
+    public virtual Task<CasdoorResponse?> AddAdapterAsync(CasdoorAdapter casdoorUserAdapter, CancellationToken cancellationToken = default)
     {
         string url = _options.GetActionUrl("add-adapter");
         return PostAsJsonAsync(url, casdoorUserAdapter, cancellationToken);

--- a/src/Casdoor.Client/CasdoorClient.CasbinApi.cs
+++ b/src/Casdoor.Client/CasdoorClient.CasbinApi.cs
@@ -16,6 +16,7 @@ using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
+using System.Net.Http;
 using IdentityModel.Client;
 
 namespace Casdoor.Client;

--- a/src/Casdoor.Client/CasdoorClient.CertApi.cs
+++ b/src/Casdoor.Client/CasdoorClient.CertApi.cs
@@ -1,0 +1,86 @@
+﻿// Copyright 2024 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Json;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Casdoor.Client;
+
+public partial class CasdoorClient
+{
+
+    public virtual Task<CasdoorResponse?> AddCertAsync(CasdoorCert cert,
+        CancellationToken cancellationToken = default)
+    {
+        string url = _options.GetActionUrl("add-cert");
+        cert.Owner = _options.OrganizationName;
+        return PostAsJsonAsync(url, cert, cancellationToken);
+    }
+
+    public virtual Task<CasdoorResponse?> DeleteCertAsync(string name, CancellationToken cancellationToken = default)
+    {
+        CasdoorCert cert = new() { Owner = _options.OrganizationName, Name = name };
+        var url = _options.GetActionUrl("delete-cert");
+        return PostAsJsonAsync(url, cert, cancellationToken);
+    }
+
+    public virtual async Task<CasdoorCert?> GetCertAsync(string name, CancellationToken cancellationToken = default)
+    {
+        var queryMap = new QueryMapBuilder()
+            .Add("id", $"{_options.OrganizationName}/{name}").QueryMap;
+        string url = _options.GetActionUrl("get-cert", queryMap);
+        var result = await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken: cancellationToken);
+        return result.DeserializeData<CasdoorCert?>();
+    }
+
+    public virtual async Task<IEnumerable<CasdoorCert>?> GetCertsAsync(CancellationToken cancellationToken = default)
+    {
+        var queryMap = new QueryMapBuilder()
+            .Add("owner", _options.OrganizationName).QueryMap;
+        string url = _options.GetActionUrl("get-certs", queryMap);
+        var result = await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken: cancellationToken);
+        return result.DeserializeData<IEnumerable<CasdoorCert>?>();
+    }
+
+    public virtual async Task<IEnumerable<CasdoorCert>?> GetGlobalCertsAsync(CancellationToken cancellationToken = default)
+    {
+        string url = _options.GetActionUrl("get-global-certs");
+        var result = await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken: cancellationToken);
+        return result.DeserializeData<IEnumerable<CasdoorCert>?>();
+    }
+
+    public virtual Task<CasdoorResponse?> UpdateCertAsync(CasdoorCert cert, CancellationToken cancellationToken = default)
+        => ModifyCertAsync("update-cert", cert, null, cancellationToken: cancellationToken);
+
+
+    private Task<CasdoorResponse?> ModifyCertAsync(string action, CasdoorCert cert, IEnumerable<string>? columns, string? owner = null, CancellationToken cancellationToken = default)
+    {
+        var queryMapBuilder = new QueryMapBuilder().Add("id", $"{cert.Owner}/{cert.Name}");
+
+        string columnsValue = string.Join(",", columns ?? Array.Empty<string>());
+
+        if (!string.IsNullOrEmpty(columnsValue))
+        {
+            queryMapBuilder.Add("columns", columnsValue);
+        }
+        cert.Owner = _options.OrganizationName;
+
+        string url = _options.GetActionUrl(action, queryMapBuilder.QueryMap);
+        return PostAsJsonAsync(url, cert, cancellationToken);
+    }
+}

--- a/src/Casdoor.Client/CasdoorClient.Internal.cs
+++ b/src/Casdoor.Client/CasdoorClient.Internal.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
 
@@ -43,5 +44,9 @@ public partial class CasdoorClient
     }
 
     internal Task<CasdoorResponse?> PostFileAsync(string? requestUri, StreamContent postStream, CancellationToken cancellationToken = default)
-        => _httpClient.PostFileAsync(requestUri, postStream, cancellationToken);
+    {
+        _httpClient.SetCasdoorAuthentication(_options);
+        return _httpClient.PostFileAsync(requestUri, postStream, cancellationToken);
+    }
+    
 }

--- a/src/Casdoor.Client/CasdoorClient.OrganizationApi.cs
+++ b/src/Casdoor.Client/CasdoorClient.OrganizationApi.cs
@@ -30,7 +30,7 @@ public partial class CasdoorClient
 
     public virtual async Task<CasdoorResponse?> DeleteOrganizationAsync(string name, CancellationToken cancellationToken = default)
     {
-        var organization = new CasdoorOrganization {Owner = CasdoorConstants.DefaultCasdoorOwner, Name = name};
+        var organization = new CasdoorOrganization { Owner = CasdoorConstants.DefaultCasdoorOwner, Name = name };
         var url = _options.GetActionUrl("delete-organization");
         return await PostAsJsonAsync(url, organization, cancellationToken);
     }
@@ -58,6 +58,15 @@ public partial class CasdoorClient
     {
         var queryMap = new QueryMapBuilder().Add("owner", owner).QueryMap;
         var url = _options.GetActionUrl("get-organizations", queryMap);
+        var response = await GetFromJsonAsync<CasdoorResponse>(url, cancellationToken: cancellationToken);
+        return response.DeserializeData<IEnumerable<CasdoorOrganization>>();
+    }
+
+    public virtual async Task<IEnumerable<CasdoorOrganization>?> GetOrganizationNamesAsync(string owner, CancellationToken cancellationToken)
+
+    {
+        var queryMap = new QueryMapBuilder().Add("owner", owner).QueryMap;
+        var url = _options.GetActionUrl("get-organization-names", queryMap);
         var response = await GetFromJsonAsync<CasdoorResponse>(url, cancellationToken: cancellationToken);
         return response.DeserializeData<IEnumerable<CasdoorOrganization>>();
     }

--- a/src/Casdoor.Client/CasdoorClient.PaymentApi.cs
+++ b/src/Casdoor.Client/CasdoorClient.PaymentApi.cs
@@ -1,0 +1,98 @@
+﻿// Copyright 2024 The Casdoor Authors.All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Runtime.CompilerServices;
+
+namespace Casdoor.Client;
+
+public partial class CasdoorClient
+{
+
+    public virtual Task<CasdoorResponse?> AddPaymentAsync(CasdoorPayment payment,
+        CancellationToken cancellationToken = default)
+    => ModifyPaymentAsync("add-payment", payment, null, cancellationToken: cancellationToken);
+
+    public virtual Task<CasdoorResponse?> UpdatePaymentAsync(CasdoorPayment payment, CancellationToken cancellationToken = default)
+    => ModifyPaymentAsync("update-payment", payment, null, cancellationToken: cancellationToken);
+
+    public virtual Task<CasdoorResponse?> NotifyPaymentAsync(CasdoorPayment payment, CancellationToken cancellationToken = default)
+    => ModifyPaymentAsync("notify-payment", payment, null, cancellationToken: cancellationToken);
+
+    public virtual Task<CasdoorResponse?> InvoicePaymentAsync(CasdoorPayment payment, CancellationToken cancellationToken = default)
+    => ModifyPaymentAsync("invoice-payment", payment, null, cancellationToken: cancellationToken);
+
+    public virtual Task<CasdoorResponse?> DeletePaymentAsync(CasdoorPayment payment, CancellationToken cancellationToken = default)
+    => ModifyPaymentAsync("delete-payment", payment, null, cancellationToken: cancellationToken);
+
+    public virtual async Task<CasdoorPayment?> GetPaymentAsync(string name, CancellationToken cancellationToken = default)
+    {
+        var queryMap = new QueryMapBuilder()
+            .Add("id", $"{_options.OrganizationName}/{name}").QueryMap;
+        string url = _options.GetActionUrl("get-payment", queryMap);
+        var result = await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken: cancellationToken);
+        return result.DeserializeData<CasdoorPayment?>();
+    }
+
+    public virtual async Task<IEnumerable<CasdoorPayment>?> GetUserPaymentsAsync(string userName, CancellationToken cancellationToken = default)
+    {
+        var queryMap = new QueryMapBuilder()
+            .Add("owner",_options.OrganizationName)
+            .Add("organization", _options.OrganizationName)
+            .Add("user", userName).QueryMap;
+        string url = _options.GetActionUrl("get-user-payment", queryMap);
+        var result = await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken: cancellationToken);
+        return result.DeserializeData<IEnumerable<CasdoorPayment>?>();
+    }
+
+    public virtual async Task<IEnumerable<CasdoorPayment>?> GetPaymentsAsync(CancellationToken cancellationToken = default)
+    {
+        var queryMap = new QueryMapBuilder()
+            .Add("owner", _options.OrganizationName).QueryMap;
+        string url = _options.GetActionUrl("get-payments", queryMap);
+        var result = await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken: cancellationToken);
+        return result.DeserializeData<IEnumerable<CasdoorPayment>?>();
+    }
+
+    public virtual async Task<IEnumerable<CasdoorPayment>?> GetPaginationPaymentsAsync(int pageSize, int p,
+        List<KeyValuePair<string, string?>>? queryMap, CancellationToken cancellationToken = default)
+    {
+        queryMap ??= new List<KeyValuePair<string, string?>>();
+        queryMap.Add(new KeyValuePair<string, string?>("owner", _options.OrganizationName));
+        queryMap.Add(new KeyValuePair<string, string?>("pageSize", pageSize.ToString()));
+        queryMap.Add(new KeyValuePair<string, string?>("p", p.ToString()));
+
+        string url = _options.GetActionUrl("get-payments", queryMap);
+        var result = await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken: cancellationToken);
+        return result.DeserializeData<IEnumerable<CasdoorPayment>?>();
+    }
+
+    private Task<CasdoorResponse?> ModifyPaymentAsync(string action, CasdoorPayment payment, IEnumerable<string>? columns, string? owner = null, CancellationToken cancellationToken = default)
+    {
+        var queryMapBuilder = new QueryMapBuilder().Add("id", $"{payment.Owner}/{payment.Name}");
+
+        string columnsValue = string.Join(",", columns ?? Array.Empty<string>());
+
+        if (!string.IsNullOrEmpty(columnsValue))
+        {
+            queryMapBuilder.Add("columns", columnsValue);
+        }
+
+        payment.Owner = _options.OrganizationName;
+
+        string url = _options.GetActionUrl(action, queryMapBuilder.QueryMap);
+        return PostAsJsonAsync(url, payment, cancellationToken);
+    }
+}

--- a/src/Casdoor.Client/CasdoorClient.PricingApi.cs
+++ b/src/Casdoor.Client/CasdoorClient.PricingApi.cs
@@ -1,0 +1,81 @@
+﻿// Copyright 2024 The Casdoor Authors.All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Runtime.CompilerServices;
+
+namespace Casdoor.Client;
+
+public partial class CasdoorClient
+{
+
+    public virtual Task<CasdoorResponse?> AddPricingAsync(CasdoorPricing pricing,
+        CancellationToken cancellationToken = default)
+    => ModifyPricingAsync("add-pricing", pricing, null, cancellationToken: cancellationToken);
+
+    public virtual Task<CasdoorResponse?> UpdatePricingAsync(CasdoorPricing pricing, CancellationToken cancellationToken = default)
+    => ModifyPricingAsync("update-pricing", pricing, null, cancellationToken: cancellationToken);
+
+    public virtual Task<CasdoorResponse?> DeletePricingAsync(CasdoorPricing pricing, CancellationToken cancellationToken = default)
+    => ModifyPricingAsync("delete-pricing", pricing, null, cancellationToken: cancellationToken);
+
+    public virtual async Task<CasdoorPricing?> GetPricingAsync(string name, CancellationToken cancellationToken = default)
+    {
+        var queryMap = new QueryMapBuilder()
+            .Add("id", $"{_options.OrganizationName}/{name}").QueryMap;
+        string url = _options.GetActionUrl("get-pricing", queryMap);
+        var result = await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken: cancellationToken);
+        return result.DeserializeData<CasdoorPricing?>();
+    }
+
+    public virtual async Task<IEnumerable<CasdoorPricing>?> GetPricingsAsync(CancellationToken cancellationToken = default)
+    {
+        var queryMap = new QueryMapBuilder()
+            .Add("owner", _options.OrganizationName).QueryMap;
+        string url = _options.GetActionUrl("get-pricings", queryMap);
+        var result = await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken: cancellationToken);
+        return result.DeserializeData<IEnumerable<CasdoorPricing>?>();
+    }
+
+    public virtual async Task<IEnumerable<CasdoorPricing>?> GetPaginationPricingsAsync(int pageSize, int p,
+        List<KeyValuePair<string, string?>>? queryMap, CancellationToken cancellationToken = default)
+    {
+        queryMap ??= new List<KeyValuePair<string, string?>>();
+        queryMap.Add(new KeyValuePair<string, string?>("owner", _options.OrganizationName));
+        queryMap.Add(new KeyValuePair<string, string?>("pageSize", pageSize.ToString()));
+        queryMap.Add(new KeyValuePair<string, string?>("p", p.ToString()));
+
+        string url = _options.GetActionUrl("get-pricings", queryMap);
+        var result = await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken: cancellationToken);
+        return result.DeserializeData<IEnumerable<CasdoorPricing>?>();
+    }
+
+    private Task<CasdoorResponse?> ModifyPricingAsync(string action, CasdoorPricing pricing, IEnumerable<string>? columns, string? owner = null, CancellationToken cancellationToken = default)
+    {
+        var queryMapBuilder = new QueryMapBuilder().Add("id", $"{pricing.Owner}/{pricing.Name}");
+
+        string columnsValue = string.Join(",", columns ?? Array.Empty<string>());
+
+        if (!string.IsNullOrEmpty(columnsValue))
+        {
+            queryMapBuilder.Add("columns", columnsValue);
+        }
+
+        pricing.Owner = _options.OrganizationName;
+
+        string url = _options.GetActionUrl(action, queryMapBuilder.QueryMap);
+        return PostAsJsonAsync(url, pricing, cancellationToken);
+    }
+}

--- a/src/Casdoor.Client/CasdoorClient.ProductApi.cs
+++ b/src/Casdoor.Client/CasdoorClient.ProductApi.cs
@@ -1,0 +1,91 @@
+﻿// Copyright 2024 The Casdoor Authors.All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Runtime.CompilerServices;
+
+namespace Casdoor.Client;
+
+public partial class CasdoorClient
+{
+
+    public virtual Task<CasdoorResponse?> AddProductAsync(CasdoorProduct product,
+        CancellationToken cancellationToken = default)
+    => ModifyProductAsync("add-product", product, null, cancellationToken: cancellationToken);
+
+    public virtual Task<CasdoorResponse?> UpdateProductAsync(CasdoorProduct product, CancellationToken cancellationToken = default)
+    => ModifyProductAsync("update-product", product, null, cancellationToken: cancellationToken);
+
+    public virtual Task<CasdoorResponse?> DeleteProductAsync(CasdoorProduct product, CancellationToken cancellationToken = default)
+    => ModifyProductAsync("delete-product", product, null, cancellationToken: cancellationToken);
+
+    public virtual async Task<CasdoorProduct?> GetProductAsync(string name, CancellationToken cancellationToken = default)
+    {
+        var queryMap = new QueryMapBuilder()
+            .Add("id", $"{_options.OrganizationName}/{name}").QueryMap;
+        string url = _options.GetActionUrl("get-product", queryMap);
+        var result = await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken: cancellationToken);
+        return result.DeserializeData<CasdoorProduct?>();
+    }
+
+    public virtual async Task<IEnumerable<CasdoorProduct>?> GetProductsAsync(CancellationToken cancellationToken = default)
+    {
+        var queryMap = new QueryMapBuilder()
+            .Add("owner", _options.OrganizationName).QueryMap;
+        string url = _options.GetActionUrl("get-products", queryMap);
+        var result = await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken: cancellationToken);
+        return result.DeserializeData<IEnumerable<CasdoorProduct>?>();
+    }
+
+    public virtual async Task<IEnumerable<CasdoorProduct>?> GetPaginationProductsAsync(int pageSize, int p,
+        List<KeyValuePair<string, string?>>? queryMap, CancellationToken cancellationToken = default)
+    {
+        queryMap ??= new List<KeyValuePair<string, string?>>();
+        queryMap.Add(new KeyValuePair<string, string?>("owner", _options.OrganizationName));
+        queryMap.Add(new KeyValuePair<string, string?>("pageSize", pageSize.ToString()));
+        queryMap.Add(new KeyValuePair<string, string?>("p", p.ToString()));
+
+        string url = _options.GetActionUrl("get-products", queryMap);
+        var result = await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken: cancellationToken);
+        return result.DeserializeData<IEnumerable<CasdoorProduct>?>();
+    }
+
+    private Task<CasdoorResponse?> ModifyProductAsync(string action, CasdoorProduct product, IEnumerable<string>? columns, string? owner = null, CancellationToken cancellationToken = default)
+    {
+        var queryMapBuilder = new QueryMapBuilder().Add("id", $"{product.Owner}/{product.Name}");
+
+        string columnsValue = string.Join(",", columns ?? Array.Empty<string>());
+
+        if (!string.IsNullOrEmpty(columnsValue))
+        {
+            queryMapBuilder.Add("columns", columnsValue);
+        }
+
+        product.Owner = _options.OrganizationName;
+
+        string url = _options.GetActionUrl(action, queryMapBuilder.QueryMap);
+        return PostAsJsonAsync(url, product, cancellationToken);
+    }
+
+    public virtual async Task<CasdoorResponse?> BuyProductAsync(string name, string providerName, CancellationToken cancellationToken = default)
+    {
+        var queryMap = new QueryMapBuilder()
+            .Add("id", $"{_options.OrganizationName}/{name}")
+            .Add("providerName", providerName).QueryMap;
+        string url = _options.GetActionUrl("buy-product", queryMap);
+        return await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken: cancellationToken);
+    }
+}
+

--- a/src/Casdoor.Client/CasdoorClient.RecordApi.cs
+++ b/src/Casdoor.Client/CasdoorClient.RecordApi.cs
@@ -1,0 +1,81 @@
+﻿// Copyright 2024 The Casdoor Authors.All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Runtime.CompilerServices;
+
+namespace Casdoor.Client;
+
+public partial class CasdoorClient
+{
+
+    public virtual Task<CasdoorResponse?> AddRecordAsync(CasdoorRecord record,
+        CancellationToken cancellationToken = default)
+    => ModifyRecordAsync("add-record", record, null, cancellationToken: cancellationToken);
+
+    public virtual Task<CasdoorResponse?> UpdateRecordAsync(CasdoorRecord record, CancellationToken cancellationToken = default)
+    => ModifyRecordAsync("update-record", record, null, cancellationToken: cancellationToken);
+
+    public virtual Task<CasdoorResponse?> DeleteRecordAsync(CasdoorRecord record, CancellationToken cancellationToken = default)
+    => ModifyRecordAsync("delete-record", record, null, cancellationToken: cancellationToken);
+
+    public virtual async Task<CasdoorRecord?> GetRecordAsync(string name, CancellationToken cancellationToken = default)
+    {
+        var queryMap = new QueryMapBuilder()
+            .Add("id", $"{_options.OrganizationName}/{name}").QueryMap;
+        string url = _options.GetActionUrl("get-record", queryMap);
+        var result = await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken: cancellationToken);
+        return result.DeserializeData<CasdoorRecord?>();
+    }
+
+    public virtual async Task<IEnumerable<CasdoorRecord>?> GetRecordsAsync(CancellationToken cancellationToken = default)
+    {
+        var queryMap = new QueryMapBuilder()
+            .Add("owner", _options.OrganizationName).QueryMap;
+        string url = _options.GetActionUrl("get-records", queryMap);
+        var result = await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken: cancellationToken);
+        return result.DeserializeData<IEnumerable<CasdoorRecord>?>();
+    }
+
+    public virtual async Task<IEnumerable<CasdoorRecord>?> GetPaginationRecordsAsync(int pageSize, int p,
+        List<KeyValuePair<string, string?>>? queryMap, CancellationToken cancellationToken = default)
+    {
+        queryMap ??= new List<KeyValuePair<string, string?>>();
+        queryMap.Add(new KeyValuePair<string, string?>("owner", _options.OrganizationName));
+        queryMap.Add(new KeyValuePair<string, string?>("pageSize", pageSize.ToString()));
+        queryMap.Add(new KeyValuePair<string, string?>("p", p.ToString()));
+
+        string url = _options.GetActionUrl("get-records", queryMap);
+        var result = await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken: cancellationToken);
+        return result.DeserializeData<IEnumerable<CasdoorRecord>?>();
+    }
+
+    private Task<CasdoorResponse?> ModifyRecordAsync(string action, CasdoorRecord record, IEnumerable<string>? columns, string? owner = null, CancellationToken cancellationToken = default)
+    {
+        var queryMapBuilder = new QueryMapBuilder().Add("id", $"{record.Owner}/{record.Name}");
+
+        string columnsValue = string.Join(",", columns ?? Array.Empty<string>());
+
+        if (!string.IsNullOrEmpty(columnsValue))
+        {
+            queryMapBuilder.Add("columns", columnsValue);
+        }
+
+        record.Owner = _options.OrganizationName;
+
+        string url = _options.GetActionUrl(action, queryMapBuilder.QueryMap);
+        return PostAsJsonAsync(url, record, cancellationToken);
+    }
+}

--- a/src/Casdoor.Client/CasdoorClient.RoleApi.cs
+++ b/src/Casdoor.Client/CasdoorClient.RoleApi.cs
@@ -37,10 +37,7 @@ public partial class CasdoorClient
 
     public virtual async Task<CasdoorResponse?> AddRoleAsync(CasdoorRole role, CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrEmpty(role.Owner))
-        {
-            role.Owner = CasdoorConstants.DefaultCasdoorOwner;
-        }
+        role.Owner = _options.OrganizationName;
 
         string url = _options.GetActionUrl("add-role");
         return await PostAsJsonAsync(url, role, cancellationToken);

--- a/src/Casdoor.Client/CasdoorClient.ServiceApi.cs
+++ b/src/Casdoor.Client/CasdoorClient.ServiceApi.cs
@@ -41,4 +41,14 @@ public partial class CasdoorClient
         string url = _options.GetActionUrl("send-email");
         return PostAsJsonAsync(url, form, cancellationToken);
     }
+
+    public virtual Task<CasdoorResponse?> SendNotification(string content, CancellationToken cancellationToken = default)
+    {
+        string url = _options.GetActionUrl("send-notification");
+        CasdoorNotificationForm form = new()
+        {
+            Content = content,
+        };
+        return PostAsJsonAsync(url, form, cancellationToken);
+    }
 }

--- a/src/Casdoor.Client/CasdoorClient.SessionApi.cs
+++ b/src/Casdoor.Client/CasdoorClient.SessionApi.cs
@@ -1,0 +1,84 @@
+﻿// Copyright 2024 The Casdoor Authors.All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Runtime.CompilerServices;
+
+namespace Casdoor.Client;
+
+public partial class CasdoorClient
+{
+
+    public virtual Task<CasdoorResponse?> AddSessionAsync(CasdoorSession session,
+        CancellationToken cancellationToken = default)
+    => ModifySessionAsync("add-session", session, null, cancellationToken: cancellationToken);
+
+    public virtual Task<CasdoorResponse?> UpdateSessionAsync(CasdoorSession session, CancellationToken cancellationToken = default)
+    => ModifySessionAsync("update-session", session, null, cancellationToken: cancellationToken);
+
+    public virtual Task<CasdoorResponse?> UpdateSessionForColumnsAsync(CasdoorSession session, IEnumerable<string> columns, CancellationToken cancellationToken = default)
+    => ModifySessionAsync("update-session", session, null, cancellationToken: cancellationToken);
+
+    public virtual Task<CasdoorResponse?> DeleteSessionAsync(CasdoorSession session, CancellationToken cancellationToken = default)
+    => ModifySessionAsync("delete-session", session, null, cancellationToken: cancellationToken);
+
+    public virtual async Task<CasdoorSession?> GetSessionAsync(string name, string application, CancellationToken cancellationToken = default)
+    {
+        var queryMap = new QueryMapBuilder()
+            .Add("sessionPkId", $"{_options.OrganizationName}/{name}/{application}").QueryMap;
+        string url = _options.GetActionUrl("get-session", queryMap);
+        var result = await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken: cancellationToken);
+        return result.DeserializeData<CasdoorSession?>();
+    }
+
+    public virtual async Task<IEnumerable<CasdoorSession>?> GetSessionsAsync(CancellationToken cancellationToken = default)
+    {
+        var queryMap = new QueryMapBuilder()
+            .Add("owner", _options.OrganizationName).QueryMap;
+        string url = _options.GetActionUrl("get-sessions", queryMap);
+        var result = await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken: cancellationToken);
+        return result.DeserializeData<IEnumerable<CasdoorSession>?>();
+    }
+
+    public virtual async Task<IEnumerable<CasdoorSession>?> GetPaginationSessionsAsync(int pageSize, int p,
+        List<KeyValuePair<string, string?>>? queryMap, CancellationToken cancellationToken = default)
+    {
+        queryMap ??= new List<KeyValuePair<string, string?>>();
+        queryMap.Add(new KeyValuePair<string, string?>("owner", _options.OrganizationName));
+        queryMap.Add(new KeyValuePair<string, string?>("pageSize", pageSize.ToString()));
+        queryMap.Add(new KeyValuePair<string, string?>("p", p.ToString()));
+
+        string url = _options.GetActionUrl("get-sessions", queryMap);
+        var result = await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken: cancellationToken);
+        return result.DeserializeData<IEnumerable<CasdoorSession>?>();
+    }
+
+    private Task<CasdoorResponse?> ModifySessionAsync(string action, CasdoorSession session, IEnumerable<string>? columns, string? owner = null, CancellationToken cancellationToken = default)
+    {
+        var queryMapBuilder = new QueryMapBuilder().Add("id", $"{session.Owner}/{session.Name}");
+
+        string columnsValue = string.Join(",", columns ?? Array.Empty<string>());
+
+        if (!string.IsNullOrEmpty(columnsValue))
+        {
+            queryMapBuilder.Add("columns", columnsValue);
+        }
+
+        session.Owner = _options.OrganizationName;
+
+        string url = _options.GetActionUrl(action, queryMapBuilder.QueryMap);
+        return PostAsJsonAsync(url, session, cancellationToken);
+    }
+}

--- a/src/Casdoor.Client/CasdoorClient.SubscriptionApi.cs
+++ b/src/Casdoor.Client/CasdoorClient.SubscriptionApi.cs
@@ -1,0 +1,76 @@
+﻿// Copyright 2024 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Json;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Casdoor.Client;
+public partial class CasdoorClient
+{
+    public virtual async Task<CasdoorResponse?> AddSubscriptionAsync(CasdoorSubscription casdoorSubscription,
+            CancellationToken cancellationToken = default)
+        => await PostAsJsonAsync(_options.GetActionUrl("add-subscription"), casdoorSubscription, cancellationToken);
+
+    public virtual async Task<CasdoorResponse?> DeleteSubscriptionAsync(CasdoorSubscription casdoorSubscription,
+            CancellationToken cancellationToken = default)
+        => await PostAsJsonAsync(_options.GetActionUrl("delete-subscription"), casdoorSubscription, cancellationToken);
+
+    public virtual async Task<CasdoorSubscription?> GetSubscriptionAsync(string owner, string name,
+        CancellationToken cancellationToken = default)
+    {
+        var queryMap = new QueryMapBuilder()
+            .Add("id", $"{owner}/{name}").QueryMap;
+
+        string url = _options.GetActionUrl("get-subscription", queryMap);
+        var result = await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken);
+        return result.DeserializeData<CasdoorSubscription?>();
+    }
+
+    public virtual async Task<IEnumerable<CasdoorSubscription>?> GetSubscriptionsAsync(string owner,
+        CancellationToken cancellationToken = default)
+    {
+        var queryMap = new QueryMapBuilder()
+             .Add("owner", owner).QueryMap;
+
+        string url = _options.GetActionUrl("get-subscriptions", queryMap);
+        var result = await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken);
+        return result.DeserializeData<IEnumerable<CasdoorSubscription>?>();
+    }
+
+    public virtual async Task<IEnumerable<CasdoorSubscription>?> GetPaginationSubscriptions(string owner, int p, int pageSize,
+        List<KeyValuePair<string, string?>> queryMap, CancellationToken cancellationToken = default)
+    {
+
+        queryMap.Add(new KeyValuePair<string, string?>("owner", owner));
+        queryMap.Add(new KeyValuePair<string, string?>("p", p.ToString()));
+        queryMap.Add(new KeyValuePair<string, string?>("pageSize", pageSize.ToString()));
+
+        string url = _options.GetActionUrl("get-subscriptions", queryMap);
+        var result = await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken);
+        return result.DeserializeData<IEnumerable<CasdoorSubscription>?>();
+    }
+
+    public virtual Task<CasdoorResponse?> UpdateSubscriptionAsync(CasdoorSubscription casdoorSubscription,
+        CancellationToken cancellationToken = default)
+    {
+        var queryMap = new QueryMapBuilder()
+             .Add("id", $"{casdoorSubscription.Owner}/{casdoorSubscription.Name}").QueryMap;
+        string url = _options.GetActionUrl("update-subscription", queryMap);
+        return PostAsJsonAsync(url, casdoorSubscription, cancellationToken);
+    }
+}

--- a/src/Casdoor.Client/CasdoorClient.SyncerApi.cs
+++ b/src/Casdoor.Client/CasdoorClient.SyncerApi.cs
@@ -1,0 +1,68 @@
+﻿// Copyright 2024 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Json;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Casdoor.Client;
+
+public partial class CasdoorClient
+{
+    public virtual async Task<CasdoorResponse?> AddSyncerAsync(CasdoorSyncer casdoorSyncer,
+            CancellationToken cancellationToken = default)
+        => await PostAsJsonAsync(_options.GetActionUrl("add-syncer"), casdoorSyncer, cancellationToken);
+
+    public virtual async Task<CasdoorResponse?> DeleteSyncerAsync(CasdoorSyncer casdoorSyncer,
+            CancellationToken cancellationToken = default)
+        => await PostAsJsonAsync(_options.GetActionUrl("delete-syncer"), casdoorSyncer, cancellationToken);
+
+    public virtual async Task<CasdoorSyncer?> GetSyncerAsync(string owner, string name,
+        CancellationToken cancellationToken = default)
+    {
+        var queryMap = new QueryMapBuilder()
+            .Add("id", $"{owner}/{name}").QueryMap;
+
+        string url = _options.GetActionUrl("get-syncer", queryMap);
+        var result = await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken);
+        return result.DeserializeData<CasdoorSyncer?>();
+    }
+
+    public virtual async Task<IEnumerable<CasdoorSyncer>?> GetSyncersAsync(string owner,
+        CancellationToken cancellationToken = default)
+    {
+        var queryMap = new QueryMapBuilder()
+             .Add("owner", owner).QueryMap;
+
+        string url = _options.GetActionUrl("get-syncers", queryMap);
+        var result = await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken);
+        return result.DeserializeData<IEnumerable<CasdoorSyncer>?>();
+    }
+
+    public virtual async Task<CasdoorResponse?> RunSyncerAsync(CasdoorSyncer casdoorSyncer,
+            CancellationToken cancellationToken = default)
+        => await PostAsJsonAsync(_options.GetActionUrl("run-syncer"), casdoorSyncer, cancellationToken);
+
+    public virtual Task<CasdoorResponse?> UpdateSyncerAsync(CasdoorSyncer casdoorSyncer,
+        CancellationToken cancellationToken = default)
+    {
+        var queryMap = new QueryMapBuilder()
+             .Add("id", $"{casdoorSyncer.Owner}/{casdoorSyncer.Name}").QueryMap;
+        string url = _options.GetActionUrl("update-syncer", queryMap);
+        return PostAsJsonAsync(url, casdoorSyncer, cancellationToken);
+    }
+}

--- a/src/Casdoor.Client/CasdoorClient.WebhookApi.cs
+++ b/src/Casdoor.Client/CasdoorClient.WebhookApi.cs
@@ -1,0 +1,65 @@
+﻿// Copyright 2024 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Json;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace Casdoor.Client;
+
+public partial class CasdoorClient
+{
+    public virtual async Task<CasdoorResponse?> AddWebhookAsync(CasdoorWebhook webhook,
+            CancellationToken cancellationToken = default) =>
+        await PostAsJsonAsync(_options.GetActionUrl("add-webhook"), webhook, cancellationToken);
+
+    public virtual async Task<CasdoorResponse?> DeleteWebhookAsync(CasdoorWebhook webhook,
+            CancellationToken cancellationToken = default) =>
+        await PostAsJsonAsync(_options.GetActionUrl("delete-webhook"), webhook, cancellationToken);
+
+    public virtual async Task<CasdoorWebhook?> GetWebhookAsync(string owner, string name,
+        CancellationToken cancellationToken = default)
+    {
+        var queryMap = new QueryMapBuilder()
+            .Add("id", $"{owner}/{name}").QueryMap;
+
+        string url = _options.GetActionUrl("get-webhook", queryMap);
+        var result = await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken);
+        return result.DeserializeData<CasdoorWebhook?>();
+    }
+
+    public virtual async Task<IEnumerable<CasdoorWebhook>?> GetWebhooksAsync(string owner,
+        CancellationToken cancellationToken = default)
+    {
+        var queryMap = new QueryMapBuilder()
+             .Add("owner",owner).QueryMap;
+
+        string url = _options.GetActionUrl("get-webhooks", queryMap);
+        var result = await _httpClient.GetFromJsonAsync<CasdoorResponse?>(url, cancellationToken);
+        return result.DeserializeData<IEnumerable<CasdoorWebhook>?>();
+    }
+
+    public virtual Task<CasdoorResponse?> UpdateWebhookAsync(CasdoorWebhook casdoorWebhook,
+        CancellationToken cancellationToken = default)
+    {
+        var queryMap = new QueryMapBuilder()
+             .Add("id", $"{casdoorWebhook.Owner}/{casdoorWebhook.Name}").QueryMap;
+        string url = _options.GetActionUrl("update-webhook", queryMap);
+        return PostAsJsonAsync(url, casdoorWebhook, cancellationToken);
+    }
+}

--- a/src/Casdoor.Client/CasdoorClient.cs
+++ b/src/Casdoor.Client/CasdoorClient.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Net.Http;
 using IdentityModel.Client;
 
 namespace Casdoor.Client;

--- a/src/Casdoor.Client/Extensions/CasdoorResponseExtension.cs
+++ b/src/Casdoor.Client/Extensions/CasdoorResponseExtension.cs
@@ -31,4 +31,18 @@ public static class CasdoorResponseExtension
 
         return default;
     }
+
+    internal static T? DeserializeData2<T>(this CasdoorResponse? response)
+    {
+        if (response?.Status != "ok")
+        {
+            throw new CasdoorApiException(response?.Msg);
+        }
+        if (response.Data2 is JsonElement element)
+        {
+            return element.Deserialize<T>();
+        }
+
+        return default;
+    }
 }

--- a/src/Casdoor.Client/Extensions/HttpClientExtension.cs
+++ b/src/Casdoor.Client/Extensions/HttpClientExtension.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Net.Http;
 using System.Net.Http.Json;
 using IdentityModel.Client;
 

--- a/src/Casdoor.Client/Models/CadoorPricing.cs
+++ b/src/Casdoor.Client/Models/CadoorPricing.cs
@@ -1,0 +1,64 @@
+﻿// Copyright 2024 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Text.Json.Serialization;
+
+namespace Casdoor.Client;
+
+public class CasdoorPricing
+{
+    [JsonPropertyName("owner")]
+    public string? Owner { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("createdTime")]
+    public string? CreatedTime { get; set; }
+
+    [JsonPropertyName("displayName")]
+    public string? DisplayName { get; set; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("plans")]
+    public string[]? Plans { get; set; }
+
+    [JsonPropertyName("isEnabled")]
+    public bool IsEnabled { get; set; }
+
+    [JsonPropertyName("trialDuration")]
+    public int TrialDuration { get; set; }
+
+    [JsonPropertyName("application")]
+    public string? Application { get; set; }
+
+    [JsonPropertyName("submitter")]
+    public string? Submitter { get; set; }
+
+    [JsonPropertyName("approver")]
+    public string? Approver { get; set; }
+
+    [JsonPropertyName("approveTime")]
+    public string? ApproveTime { get; set; }
+
+    [JsonPropertyName("state")]
+    public string? State { get; set; }
+}

--- a/src/Casdoor.Client/Models/CasdoorAccount.cs
+++ b/src/Casdoor.Client/Models/CasdoorAccount.cs
@@ -1,0 +1,98 @@
+﻿// Copyright 2024 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Text.Json.Serialization;
+
+namespace Casdoor.Client;
+
+public class CasdoorAccount
+{
+    public CasdoorUser? cassdoorUser { get; set; }
+    public CasdoorOrganization? casdoorOrganization {get; set;}
+
+    public CasdoorAccount(CasdoorUser? cassdoorUser, CasdoorOrganization? casdoorOrganization)
+    {
+        this.cassdoorUser = cassdoorUser;
+        this.casdoorOrganization = casdoorOrganization;
+    }
+}
+
+public class CasdoorResetEmailOrPhoneForm
+{
+    [JsonPropertyName("dest")]
+    public string? Dest { get; set;}
+
+    [JsonPropertyName("type")]
+    public string? Type { get; set;}
+
+    [JsonPropertyName("code")]
+    public string? Code { get; set;}
+}
+
+public class CasdoorLaravelResponse
+{
+    [JsonPropertyName("created_at")]
+    public string? CreatedAt { get; set; }
+
+    [JsonPropertyName("email")]
+    public string? Email { get; set; }
+
+    [JsonPropertyName("email_verified_at")]
+    public string? EmailVerifiedAt { get; set; }
+
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("updated_at")]
+    public string? UpdatedAt { get; set; }
+}
+
+public class CasdoorUserInfo
+{
+    [JsonPropertyName("address")]
+    public string? Address { get; set; }
+
+    [JsonPropertyName("aud")]
+    public string? Aud { get; set; }
+
+    [JsonPropertyName("email")]
+    public string? Email { get; set; }
+
+    [JsonPropertyName("email_verified")]
+    public string? EmailVerified { get; set; }
+
+    [JsonPropertyName("groups")]
+    public List<string>? Groups { get; set; }
+
+    [JsonPropertyName("iss")]
+    public string? Iss { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("phone")]
+    public string? Phone { get; set; }
+
+    [JsonPropertyName("picture")]
+    public string? Picture { get; set; }
+
+    [JsonPropertyName("preferred_username")]
+    public string? PreferredUsername { get; set; }
+
+    [JsonPropertyName("sub")]
+    public string? Sub { get; set; }
+}

--- a/src/Casdoor.Client/Models/CasdoorAdapter.cs
+++ b/src/Casdoor.Client/Models/CasdoorAdapter.cs
@@ -1,0 +1,76 @@
+﻿// Copyright 2024 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Text.Json.Serialization;
+
+namespace Casdoor.Client;
+
+
+public class CasdoorAdapter
+{
+    
+    [JsonPropertyName("owner")]
+    public string? Owner { get; set; }
+
+    
+    
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    
+    [JsonPropertyName("createdTime")]
+    public string? CreatedTime { get; set; }
+
+    
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
+    
+    [JsonPropertyName("databaseType")]
+    public string? DatabaseType { get; set; }
+
+    
+    [JsonPropertyName("host")]
+    public string? Host { get; set; }
+
+    [JsonPropertyName("port")]
+    public int Port { get; set; }
+
+    
+    [JsonPropertyName("user")]
+    public string? User { get; set; }
+
+    
+    [JsonPropertyName("password")]
+    public string? Password { get; set; }
+
+    
+    [JsonPropertyName("database")]
+    public string? Database { get; set; }
+
+    
+    [JsonPropertyName("table")]
+    public string? Table { get; set; }
+
+    [JsonPropertyName("tableNamePrefix")]
+    public string? TableNamePrefix { get; set; }
+
+    [JsonPropertyName("isEnabled")]
+    public bool IsEnabled { get; set; }
+}

--- a/src/Casdoor.Client/Models/CasdoorCert.cs
+++ b/src/Casdoor.Client/Models/CasdoorCert.cs
@@ -1,0 +1,64 @@
+﻿// Copyright 2024 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Text.Json.Serialization;
+
+namespace Casdoor.Client;
+
+public class CasdoorCert
+{
+    [JsonPropertyName("owner")]
+    public string? Owner { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("createdTime")]
+    public string? CreatedTime { get; set; }
+
+    [JsonPropertyName("displayName")]
+    public string? DisplayName { get; set; }
+
+    [JsonPropertyName("scope")]
+    public string? Scope { get; set; }
+
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
+    [JsonPropertyName("cryptoAlgorithm")]
+    public string? CryptoAlgorithm { get; set; }
+
+    [JsonPropertyName("bitSize")]
+    public int BitSize { get; set; }
+
+    [JsonPropertyName("expireInYears")]
+    public int ExpireInYears { get; set; }
+
+    [JsonPropertyName("certificate")]
+    public string? Certificate { get; set; }
+
+    [JsonPropertyName("privateKey")]
+    public string? PrivateKey { get; set; }
+
+    [JsonPropertyName("authorityPublicKey")]
+    public string? AuthorityPublicKey { get; set; }
+
+    [JsonPropertyName("authorityRootPublicKey")]
+    public string? AuthorityRootPublicKey { get; set; }
+}

--- a/src/Casdoor.Client/Models/CasdoorEmailForm.cs
+++ b/src/Casdoor.Client/Models/CasdoorEmailForm.cs
@@ -31,5 +31,5 @@ public class CasdoorEmailForm
     public string[] Receivers { get; set; } = Array.Empty<string>();
 
     [JsonPropertyName("provider")]
-    public string Provider { get; set; }
+    public string? Provider { get; set; }
 }

--- a/src/Casdoor.Client/Models/CasdoorNotificationForm.cs
+++ b/src/Casdoor.Client/Models/CasdoorNotificationForm.cs
@@ -1,0 +1,23 @@
+﻿// Copyright 2024 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Text.Json.Serialization;
+
+namespace Casdoor.Client;
+
+public class CasdoorNotificationForm
+{
+    [JsonPropertyName("content")]
+    public string Content { get; set; } = string.Empty;
+}

--- a/src/Casdoor.Client/Models/CasdoorPayment.cs
+++ b/src/Casdoor.Client/Models/CasdoorPayment.cs
@@ -1,0 +1,110 @@
+﻿// Copyright 2024 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Casdoor.Client;
+
+using System.Text.Json.Serialization;
+
+public class CasdoorPayment
+{
+    [JsonPropertyName("owner")]
+    public string? Owner { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("createdTime")]
+    public string? CreatedTime { get; set; }
+
+    [JsonPropertyName("displayName")]
+    public string? DisplayName { get; set; }
+
+    // Payment Provider Info
+    [JsonPropertyName("provider")]
+    public string? Provider { get; set; }
+
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
+    // Product Info
+    [JsonPropertyName("productName")]
+    public string? ProductName { get; set; }
+
+    [JsonPropertyName("productDisplayName")]
+    public string? ProductDisplayName { get; set; }
+
+    [JsonPropertyName("detail")]
+    public string? Detail { get; set; }
+
+    [JsonPropertyName("tag")]
+    public string? Tag { get; set; }
+
+    [JsonPropertyName("currency")]
+    public string? Currency { get; set; }
+
+    [JsonPropertyName("price")]
+    public double Price { get; set; }
+
+    [JsonPropertyName("returnUrl")]
+    public string? ReturnUrl { get; set; }
+
+    // Payer Info
+    [JsonPropertyName("user")]
+    public string? User { get; set; }
+
+    [JsonPropertyName("personName")]
+    public string? PersonName { get; set; }
+
+    [JsonPropertyName("personIdCard")]
+    public string? PersonIdCard { get; set; }
+
+    [JsonPropertyName("personEmail")]
+    public string? PersonEmail { get; set; }
+
+    [JsonPropertyName("personPhone")]
+    public string? PersonPhone { get; set; }
+
+    [JsonPropertyName("invoiceType")]
+    public string? InvoiceType { get; set; }
+
+    [JsonPropertyName("invoiceTitle")]
+    public string? InvoiceTitle { get; set; }
+
+    [JsonPropertyName("invoiceTaxId")]
+    public string? InvoiceTaxId { get; set; }
+
+    [JsonPropertyName("invoiceRemark")]
+    public string? InvoiceRemark { get; set; }
+
+    [JsonPropertyName("invoiceUrl")]
+    public string? InvoiceUrl { get; set; }
+
+    [JsonPropertyName("outOrderId")]
+    public string? OutOrderId { get; set; }
+
+    [JsonPropertyName("payUrl")]
+    public string? PayUrl { get; set; }
+
+    [JsonPropertyName("state")]
+    public string? State { get; set; }
+
+    [JsonPropertyName("message")]
+    public string? Message { get; set; }
+}

--- a/src/Casdoor.Client/Models/CasdoorPermission.cs
+++ b/src/Casdoor.Client/Models/CasdoorPermission.cs
@@ -78,4 +78,7 @@ public class CasdoorPermission
 
     [JsonPropertyName("isEnabled")]
     public bool IsEnabled { get; set; }
+
+    [JsonPropertyName("groups")]
+    public IEnumerable<string>? Groups { get; set; }
 }

--- a/src/Casdoor.Client/Models/CasdoorPlan.cs
+++ b/src/Casdoor.Client/Models/CasdoorPlan.cs
@@ -30,8 +30,8 @@ public class CasdoorPlan
 
     [JsonPropertyName("pricePerMonth")] public double PricePerMonth { get; set; }
     [JsonPropertyName("pricePerYear")] public double PricePerYear { get; set; }
-    [JsonPropertyName("currency")] public string Currency { get; set; }
+    [JsonPropertyName("currency")] public string? Currency { get; set; }
     [JsonPropertyName("isEnabled")] public bool IsEnabled { get; set; }
-    [JsonPropertyName("role")] public string Role { get; set; }
-    [JsonPropertyName("options")] public List<string> Options { get; set; }
+    [JsonPropertyName("role")] public string? Role { get; set; }
+    [JsonPropertyName("options")] public List<string>? Options { get; set; }
 }

--- a/src/Casdoor.Client/Models/CasdoorProduce.cs
+++ b/src/Casdoor.Client/Models/CasdoorProduce.cs
@@ -1,0 +1,73 @@
+﻿// Copyright 2024 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace Casdoor.Client;
+
+public class CasdoorProduct
+{
+    [JsonPropertyName("owner")]
+    public string? Owner { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("createdTime")]
+    public string? CreatedTime { get; set; }
+
+    [JsonPropertyName("displayName")]
+    public string? DisplayName { get; set; }
+
+    [JsonPropertyName("image")]
+    public string? Image { get; set; }
+
+    [JsonPropertyName("detail")]
+    public string? Detail { get; set; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("tag")]
+    public string? Tag { get; set; }
+
+    [JsonPropertyName("currency")]
+    public string? Currency { get; set; }
+
+    [JsonPropertyName("price")]
+    public double? Price { get; set; }
+
+    [JsonPropertyName("quantity")]
+    public int? Quantity { get; set; }
+
+    [JsonPropertyName("sold")]
+    public int? Sold { get; set; }
+
+    [JsonPropertyName("providers")]
+    public IEnumerable<string>? Providers { get; set; }
+
+    [JsonPropertyName("returnUrl")]
+    public string? ReturnUrl { get; set; }
+
+    [JsonPropertyName("state")]
+    public string? State { get; set; }
+
+    [JsonPropertyName("providerObjs")]
+    public IEnumerable<CasdoorProvider>? ProviderObjs { get; set; }
+}

--- a/src/Casdoor.Client/Models/CasdoorRecord.cs
+++ b/src/Casdoor.Client/Models/CasdoorRecord.cs
@@ -1,0 +1,63 @@
+﻿// Copyright 2024 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace Casdoor.Client;
+public class CasdoorRecord
+{
+    [JsonPropertyName("id")]
+    public int Id { get; set; }
+
+    [JsonPropertyName("owner")]
+    public string? Owner { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("createdTime")]
+    public string? CreatedTime { get; set; }
+
+    [JsonPropertyName("organization")]
+    public string? Organization { get; set; }
+
+    [JsonPropertyName("clientIp")]
+    public string? ClientIp { get; set; }
+
+    [JsonPropertyName("user")]
+    public string? User { get; set; }
+
+    [JsonPropertyName("method")]
+    public string? Method { get; set; }
+
+    [JsonPropertyName("requestUri")]
+    public string? RequestUri { get; set; }
+
+    [JsonPropertyName("action")]
+    public string? Action { get; set; }
+
+    [JsonPropertyName("object")]
+    public string? Object { get; set; }
+
+    [JsonPropertyName("extendedUser")]
+    public CasdoorUser? ExtendedUser { get; set; }
+
+    [JsonPropertyName("isTriggered")]
+    public bool IsTriggered { get; set; }
+}

--- a/src/Casdoor.Client/Models/CasdoorSession.cs
+++ b/src/Casdoor.Client/Models/CasdoorSession.cs
@@ -1,0 +1,40 @@
+﻿// Copyright 2024 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace Casdoor.Client;
+
+public class CasdoorSession
+{
+    [JsonPropertyName("owner")]
+    public string? Owner { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("application")]
+    public string? Application { get; set; }
+
+    [JsonPropertyName("createdTime")]
+    public string? CreatedTime { get; set; }
+
+    [JsonPropertyName("sessionId")]
+    public IEnumerable<string>? SessionId { get; set; }
+}

--- a/src/Casdoor.Client/Models/CasdoorSubscription.cs
+++ b/src/Casdoor.Client/Models/CasdoorSubscription.cs
@@ -1,0 +1,70 @@
+﻿// Copyright 2024 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace Casdoor.Client;
+
+public class CasdoorSubscription
+{
+    [JsonPropertyName("owner")]
+    public string? Owner { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("createdTime")]
+    public string? CreatedTime { get; set; }
+
+    [JsonPropertyName("displayName")]
+    public string? DisplayName { get; set; }
+
+    [JsonPropertyName("startDate")]
+    public DateTime? StartDate { get; set; }
+
+    [JsonPropertyName("endDate")]
+    public DateTime? EndDate { get; set; }
+
+    [JsonPropertyName("duration")]
+    public int? Duration { get; set; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("user")]
+    public string? User { get; set; }
+
+    [JsonPropertyName("plan")]
+    public string? Plan { get; set; }
+
+    [JsonPropertyName("isEnabled")]
+    public bool? IsEnabled { get; set; }
+
+    [JsonPropertyName("submitter")]
+    public string? Submitter { get; set; }
+
+    [JsonPropertyName("approver")]
+    public string? Approver { get; set; }
+
+    [JsonPropertyName("approveTime")]
+    public string? ApproveTime { get; set; }
+
+    [JsonPropertyName("state")]
+    public string? State { get; set; }
+}

--- a/src/Casdoor.Client/Models/CasdoorSyncer.cs
+++ b/src/Casdoor.Client/Models/CasdoorSyncer.cs
@@ -1,0 +1,106 @@
+﻿// Copyright 2024 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace Casdoor.Client;
+
+public class TableColumnsItem
+{
+    [JsonPropertyName("casdoorName")]
+    public string? CasdoorName { get; set; }
+
+    [JsonPropertyName("isHashed")]
+    public bool? IsHashed { get; set; }
+
+    [JsonPropertyName("isKey")]
+    public bool? IsKey { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
+    [JsonPropertyName("values")]
+    public IEnumerable<string>? Values { get; set; }
+}
+
+public class CasdoorSyncer
+{
+    [JsonPropertyName("affiliationTable")]
+    public string? AffiliationTable { get; set; }
+
+    [JsonPropertyName("avatarBaseUrl")]
+    public string? AvatarBaseUrl { get; set; }
+
+    [JsonPropertyName("createdTime")]
+    public string? CreatedTime { get; set; }
+
+    [JsonPropertyName("database")]
+    public string? Database { get; set; }
+
+    [JsonPropertyName("databaseType")]
+    public string? DatabaseType { get; set; }
+
+    [JsonPropertyName("errorText")]
+    public string? ErrorText { get; set; }
+
+    [JsonPropertyName("host")]
+    public string? Host { get; set; }
+
+    [JsonPropertyName("isEnabled")]
+    public bool? IsEnabled { get; set; }
+
+    [JsonPropertyName("isReadOnly")]
+    public bool? IsReadOnly { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("organization")]
+    public string? Organization { get; set; }
+
+    [JsonPropertyName("owner")]
+    public string? Owner { get; set; }
+
+    [JsonPropertyName("password")]
+    public string? Password { get; set; }
+
+    [JsonPropertyName("port")]
+    public int Port { get; set; }
+
+    [JsonPropertyName("sslMode")]
+    public string? SslMode { get; set; }
+
+    [JsonPropertyName("syncInterval")]
+    public int SyncInterval { get; set; }
+
+    [JsonPropertyName("table")]
+    public string? Table { get; set; }
+
+    [JsonPropertyName("tableColumns")]
+    public IEnumerable<TableColumnsItem>? TableColumns { get; set; }
+
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
+    [JsonPropertyName("user")]
+    public string? User { get; set; }
+}

--- a/src/Casdoor.Client/Models/CasdoorThemeData.cs
+++ b/src/Casdoor.Client/Models/CasdoorThemeData.cs
@@ -1,3 +1,17 @@
+// Copyright 2024 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System.Text.Json.Serialization;
 
 namespace Casdoor.Client;

--- a/src/Casdoor.Client/Models/CasdoorToken.cs
+++ b/src/Casdoor.Client/Models/CasdoorToken.cs
@@ -1,0 +1,70 @@
+﻿// Copyright 2024 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace Casdoor.Client;
+
+public class CasdoorToken
+{
+    [JsonPropertyName("accessToken")]
+    public string? AccessToken { get; set; }
+
+    [JsonPropertyName("application")]
+    public string? Application { get; set; }
+
+    [JsonPropertyName("code")]
+    public string? Code { get; set; }
+
+    [JsonPropertyName("codeChallenge")]
+    public string? CodeChallenge { get; set; }
+
+    [JsonPropertyName("codeExpireIn")]
+    public long? CodeExpireIn { get; set; }
+
+    [JsonPropertyName("codeIsUsed")]
+    public bool? CodeIsUsed { get; set; }
+
+    [JsonPropertyName("createdTime")]
+    public string? CreatedTime { get; set; }
+
+    [JsonPropertyName("expiresIn")]
+    public long? ExpiresIn { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("organization")]
+    public string? Organization { get; set; }
+
+    [JsonPropertyName("owner")]
+    public string? Owner { get; set; }
+
+    [JsonPropertyName("refreshToken")]
+    public string? RefreshToken { get; set; }
+
+    [JsonPropertyName("scope")]
+    public string? Scope { get; set; }
+
+    [JsonPropertyName("tokenType")]
+    public string? TokenType { get; set; }
+
+    [JsonPropertyName("user")]
+    public string? User { get; set; }
+}

--- a/src/Casdoor.Client/Models/CasdoorUserResource.cs
+++ b/src/Casdoor.Client/Models/CasdoorUserResource.cs
@@ -23,4 +23,40 @@ public class CasdoorUserResource
 
     [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("application")]
+    public string? Application { get; set; }
+
+    [JsonPropertyName("createdTime")]
+    public string? CreatedTime { get; set; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("fileFormat")]
+    public string? FileFormat { get; set; }
+
+    [JsonPropertyName("fileName")]
+    public string? FileName { get; set; }
+
+    [JsonPropertyName("fileSize")]
+    public long? FileSize { get; set; }
+
+    [JsonPropertyName("fileType")]
+    public string? FileType { get; set; }
+
+    [JsonPropertyName("parent")]
+    public string? Parent { get; set; }
+
+    [JsonPropertyName("provider")]
+    public string? Provider { get; set; }
+
+    [JsonPropertyName("tag")]
+    public string? Tag { get; set; }
+
+    [JsonPropertyName("url")]
+    public string? Url { get; set; }
+
+    [JsonPropertyName("user")]
+    public string? User { get; set; }
 }

--- a/src/Casdoor.Client/Models/CasdoorWebhook.cs
+++ b/src/Casdoor.Client/Models/CasdoorWebhook.cs
@@ -1,0 +1,84 @@
+﻿// Copyright 2024 The Casdoor Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace Casdoor.Client;
+public class CasdoorWebhook
+{
+    [JsonPropertyName("owner")]
+    public string? Owner { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("createdTime")]
+    public string? CreatedTime { get; set; }
+
+    [JsonPropertyName("organization")]
+    public string? Organization { get; set; }
+
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
+    [JsonPropertyName("host")]
+    public string? Host { get; set; }
+
+    [JsonPropertyName("port")]
+    public int Port { get; set; }
+
+    [JsonPropertyName("user")]
+    public string? User { get; set; }
+
+    [JsonPropertyName("password")]
+    public string? Password { get; set; }
+
+    [JsonPropertyName("databaseType")]
+    public string? DatabaseType { get; set; }
+
+    [JsonPropertyName("database")]
+    public string? Database { get; set; }
+
+    [JsonPropertyName("table")]
+    public string? Table { get; set; }
+
+    [JsonPropertyName("tablePrimaryKey")]
+    public string? TablePrimaryKey { get; set; }
+
+    [JsonPropertyName("tableColumns")]
+    public List<TableColumnsItem>? TableColumns { get; set; }
+
+    [JsonPropertyName("affiliationTable")]
+    public string? AffiliationTable { get; set; }
+
+    [JsonPropertyName("avatarBaseUrl")]
+    public string? AvatarBaseUrl { get; set; }
+
+    [JsonPropertyName("errorText")]
+    public string? ErrorText { get; set; }
+
+    [JsonPropertyName("syncInterval")]
+    public int SyncInterval { get; set; }
+
+    [JsonPropertyName("isReadOnly")]
+    public bool IsReadOnly { get; set; }
+
+    [JsonPropertyName("isEnabled")]
+    public bool IsEnabled { get; set; }
+}

--- a/tests/Casdoor.Client.UnitTests/ApiClientTests/AdapterTest.cs
+++ b/tests/Casdoor.Client.UnitTests/ApiClientTests/AdapterTest.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Casdoor.Client.UnitTests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+
+namespace Casdoor.Client.UnitTests.ApiClientTests;
+
+public class AdapterTest : IClassFixture<ServicesFixture>
+{
+    private readonly ServicesFixture _servicesFixture;
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public AdapterTest(ServicesFixture servicesFixture, ITestOutputHelper testOutputHelper)
+    {
+        _servicesFixture = servicesFixture;
+        _testOutputHelper = testOutputHelper;
+    }
+
+    [Fact]
+    public async void TestAdapter()
+    {
+        var userClient = _servicesFixture.ServiceProvider.GetService<ICasdoorClient>();
+
+
+        const string ownerName = "admin";
+        string name = "Adapter_" + new DateTimeOffset(DateTime.UtcNow).ToUnixTimeSeconds().ToString();
+
+        var adapter = new CasdoorAdapter()
+        {
+            Owner = ownerName,
+            Name = name,
+            CreatedTime = DateTime.Now.ToString(CultureInfo.InvariantCulture),
+            User = name,
+            Host = "https://casdoor.org"
+        };
+
+        // Add a new object
+
+        Task<CasdoorResponse?> responseAsync = userClient.AddAdapterAsync(adapter);
+        CasdoorResponse? response = await responseAsync;
+        _testOutputHelper.WriteLine($"{response.Status} {response.Msg}");
+        Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+        // Get all objects, check if our added object is inside the list
+        Task<IEnumerable<CasdoorAdapter>?> adaptersAsync = userClient.GetAdaptersAsync(ownerName);
+        IEnumerable<CasdoorAdapter>? getAdapters = await adaptersAsync;
+        Assert.True(getAdapters.Any());
+        _testOutputHelper.WriteLine($"{getAdapters.Count()}");
+        bool found = false;
+        foreach (CasdoorAdapter casdoorAdapter in getAdapters)
+        {
+            _testOutputHelper.WriteLine(casdoorAdapter.Name);
+            if (casdoorAdapter.Name == name)
+            {
+                found = true;
+            }
+        }
+
+        Assert.True(found);
+
+        // Get the object
+        Task<CasdoorAdapter?> adapterAsync = userClient.GetAdapterAsync(ownerName, name);
+        CasdoorAdapter? getAdapter = await adapterAsync;
+        Assert.Equal(name, getAdapter.Name);
+        //Update the object
+        const string updatedUser = "Updated Casdoor Website";
+        adapter.User = updatedUser;
+        // Update the object
+        responseAsync =
+            userClient.UpdateAdapterAsync(adapter, null);
+        response = await responseAsync;
+        Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+        // Validate the update
+        adapterAsync = userClient.GetAdapterAsync(ownerName, name);
+        getAdapter = await adapterAsync;
+        Assert.Equal(updatedUser, getAdapter.User);
+
+        // Delete the object
+        responseAsync = userClient.DeleteAdapterAsync(ownerName, name);
+        response = await responseAsync;
+        Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+        // Validate the deletion
+        adapterAsync = userClient.GetAdapterAsync(ownerName, name);
+        getAdapter = await adapterAsync;
+        Assert.Null(getAdapter);
+    }
+}

--- a/tests/Casdoor.Client.UnitTests/ApiClientTests/CertsTest.cs
+++ b/tests/Casdoor.Client.UnitTests/ApiClientTests/CertsTest.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Casdoor.Client.UnitTests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+
+namespace Casdoor.Client.UnitTests.ApiClientTests;
+
+public class CertTest : IClassFixture<ServicesFixture>
+{
+    private readonly ServicesFixture _servicesFixture;
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public CertTest(ServicesFixture servicesFixture, ITestOutputHelper testOutputHelper)
+    {
+        _servicesFixture = servicesFixture;
+        _testOutputHelper = testOutputHelper;
+    }
+
+    [Fact]
+    public async void TestCert()
+    {
+        var userClient = _servicesFixture.ServiceProvider.GetService<ICasdoorClient>();
+
+
+        const string ownerName = "admin";
+        string name = "Cert_" + new DateTimeOffset(DateTime.UtcNow).ToUnixTimeSeconds().ToString();
+
+        var cert = new CasdoorCert()
+        {
+            Owner = ownerName,
+            Name = name,
+            CreatedTime = DateTime.Now.ToString(CultureInfo.InvariantCulture),
+            DisplayName = name,
+            Scope = "JWT",
+            Type = "x509",
+            CryptoAlgorithm = "RS256",
+            BitSize = 4096,
+            ExpireInYears = 20,
+        };
+
+        // Add a new object
+
+        Task<CasdoorResponse?> responseAsync = userClient.AddCertAsync(cert);
+        CasdoorResponse? response = await responseAsync;
+        _testOutputHelper.WriteLine($"{response.Status} {response.Msg}");
+        Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+        // Get all objects, check if our added object is inside the list
+        Task<IEnumerable<CasdoorCert>?> certsAsync = userClient.GetCertsAsync();
+        IEnumerable<CasdoorCert>? getCerts = await certsAsync;
+        Assert.True(getCerts.Any());
+        _testOutputHelper.WriteLine($"{getCerts.Count()}");
+        bool found = false;
+        foreach (CasdoorCert casdoorCert in getCerts)
+        {
+            _testOutputHelper.WriteLine(casdoorCert.Name);
+            if (casdoorCert.Name == name)
+            {
+                found = true;
+            }
+        }
+
+        Assert.True(found);
+
+        // Get the object
+        Task<CasdoorCert?> certAsync = userClient.GetCertAsync(name);
+        CasdoorCert? getCert = await certAsync;
+        Assert.Equal(name, getCert.Name);
+        //Update the object
+        const string updatedDisplayName = "Updated Casdoor Website";
+        cert.DisplayName = updatedDisplayName;
+        // Update the object
+        responseAsync =
+            userClient.UpdateCertAsync(cert);
+        response = await responseAsync;
+        Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+        // Validate the update
+        certAsync = userClient.GetCertAsync(name);
+        getCert = await certAsync;
+        Assert.Equal(updatedDisplayName, getCert.DisplayName);
+
+        // Delete the object
+        responseAsync = userClient.DeleteCertAsync(name);
+        response = await responseAsync;
+        Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+        // Validate the deletion
+        certAsync = userClient.GetCertAsync(name);
+        getCert = await certAsync;
+        Assert.Null(getCert);
+    }
+}

--- a/tests/Casdoor.Client.UnitTests/ApiClientTests/OrganizationTest.cs
+++ b/tests/Casdoor.Client.UnitTests/ApiClientTests/OrganizationTest.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Casdoor.Client.UnitTests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+
+namespace Casdoor.Client.UnitTests.ApiClientTests;
+
+public class OrganizationTest : IClassFixture<ServicesFixture>
+{
+    private readonly ServicesFixture _servicesFixture;
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public OrganizationTest(ServicesFixture servicesFixture, ITestOutputHelper testOutputHelper)
+    {
+        _servicesFixture = servicesFixture;
+        _testOutputHelper = testOutputHelper;
+    }
+
+    [Fact]
+    public async void TestOrganization()
+    {
+        var organizationClient = _servicesFixture.ServiceProvider.GetService<ICasdoorClient>();
+        string name = "Organization_" + new DateTimeOffset(DateTime.UtcNow).ToUnixTimeSeconds().ToString();
+        _testOutputHelper.WriteLine($"test with organization name {name}");
+        string owner = "admin";
+
+        CasdoorOrganization organization = new CasdoorOrganization()
+        {
+            Owner = owner,
+            Name = name,
+            CreatedTime = DateTime.Now.ToString(),
+            DisplayName = name,
+            WebsiteUrl = "https://example.com",
+            PasswordType = "plain",
+            PasswordOptions = new string[]{ "AtLeast6"},
+            CountryCodes = new string[]{ "US", "ES", "FR", "DE", "GB", "CN", "JP", "KR", "VN", "ID", "SG", "IN"},
+            Tags = new string[] { },
+            Languages = new string[] { "en", "zh", "es", "fr", "de", "id", "ja", "ko", "ru", "vi", "pt" },
+            InitScore = 2000,
+            EnableSoftDeletion = false,
+            IsProfilePublic = false,
+        };
+
+        // Add the object
+        Task<CasdoorResponse?> responseAsync = organizationClient.AddOrganizationAsync(organization);
+        CasdoorResponse? response = await responseAsync;
+        _testOutputHelper.WriteLine($"{response.Status} {response.Msg}");
+        Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+        // Get the object
+        Task<CasdoorOrganization?> organizationAsync = organizationClient.GetOrganizationAsync($"admin/{name}");
+        CasdoorOrganization? getOrganization = await organizationAsync;
+        Assert.Equal(name, getOrganization.Name);
+
+        // Update the object
+        string updatedDisplayName = "Updated Casdoor Website";
+        getOrganization.DisplayName = updatedDisplayName;
+        responseAsync = organizationClient.UpdateOrganizationAsync($"admin/{name}",getOrganization);
+        response = await responseAsync;
+        Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+        // Validate the update
+        organizationAsync = organizationClient.GetOrganizationAsync($"admin/{name}");
+        getOrganization = await organizationAsync;
+        Assert.Equal(updatedDisplayName, getOrganization.DisplayName);
+
+        // Delete the object
+        responseAsync = organizationClient.DeleteOrganizationAsync(name);
+        response = await responseAsync;
+        Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+        // Validate the deletion
+        organizationAsync = organizationClient.GetOrganizationAsync($"admin/{name}");
+        getOrganization = await organizationAsync;
+        Assert.Null(getOrganization);
+    }
+}

--- a/tests/Casdoor.Client.UnitTests/ApiClientTests/PaymentTest.cs
+++ b/tests/Casdoor.Client.UnitTests/ApiClientTests/PaymentTest.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Casdoor.Client.UnitTests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+
+namespace Casdoor.Client.UnitTests.ApiClientTests
+{
+    public class PaymentTest : IClassFixture<ServicesFixture>
+    {
+        private readonly ServicesFixture _servicesFixture;
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public PaymentTest(ServicesFixture servicesFixture, ITestOutputHelper testOutputHelper)
+        {
+            _servicesFixture = servicesFixture;
+            _testOutputHelper = testOutputHelper;
+        }
+
+        [Fact]
+        public async void TestPayment()
+        {
+            var userClient = _servicesFixture.ServiceProvider.GetService<ICasdoorClient>();
+
+            const string ownerName = "admin";
+            string name = "Payment_" + new DateTimeOffset(DateTime.UtcNow).ToUnixTimeSeconds().ToString();
+
+            var payment = new CasdoorPayment()
+            {
+                Owner = ownerName,
+                Name = name,
+                CreatedTime = DateTime.Now.ToString(CultureInfo.InvariantCulture),
+                DisplayName = name,
+                ProductName = "casbin",
+            };
+
+            // Add a new object
+            Task<CasdoorResponse?> responseAsync = userClient.AddPaymentAsync(payment);
+            CasdoorResponse? response = await responseAsync;
+            _testOutputHelper.WriteLine($"{response.Status} {response.Msg}");
+            Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+            // Get all objects, check if our added object is inside the list
+            Task<IEnumerable<CasdoorPayment>?> paymentsAsync = userClient.GetPaymentsAsync();
+            IEnumerable<CasdoorPayment>? getPayments = await paymentsAsync;
+            Assert.True(getPayments.Any());
+            _testOutputHelper.WriteLine($"{getPayments.Count()}");
+            bool found = false;
+            foreach (CasdoorPayment casdoorPayment in getPayments)
+            {
+                _testOutputHelper.WriteLine(casdoorPayment.Name);
+                if (casdoorPayment.Name == name)
+                {
+                    found = true;
+                }
+            }
+
+            Assert.True(found);
+
+            // Get the object
+            Task<CasdoorPayment?> paymentAsync = userClient.GetPaymentAsync(name);
+            CasdoorPayment? getPayment = await paymentAsync;
+            Assert.Equal(name, getPayment.Name);
+
+            // Update the object
+            const string updatedProductName = "Updated Casdoor Payment";
+            payment.ProductName = updatedProductName;
+
+            // Update the object
+            responseAsync = userClient.UpdatePaymentAsync(payment);
+            response = await responseAsync;
+            Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+            // Validate the update
+            paymentAsync = userClient.GetPaymentAsync(name);
+            getPayment = await paymentAsync;
+            Assert.Equal(updatedProductName, getPayment.ProductName);
+
+            // Delete the object
+            responseAsync = userClient.DeletePaymentAsync(getPayment);
+            response = await responseAsync;
+            Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+            // Validate the deletion
+            paymentAsync = userClient.GetPaymentAsync(name);
+            getPayment = await paymentAsync;
+            Assert.Null(getPayment);
+        }
+    }
+}

--- a/tests/Casdoor.Client.UnitTests/ApiClientTests/PermissionTest.cs
+++ b/tests/Casdoor.Client.UnitTests/ApiClientTests/PermissionTest.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Casdoor.Client.UnitTests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+
+namespace Casdoor.Client.UnitTests.ApiClientTests;
+
+public class PermissionTest : IClassFixture<ServicesFixture>
+{
+    private readonly ServicesFixture _servicesFixture;
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public PermissionTest(ServicesFixture servicesFixture, ITestOutputHelper testOutputHelper)
+    {
+        _servicesFixture = servicesFixture;
+        _testOutputHelper = testOutputHelper;
+    }
+
+    [Fact]
+    public async void TestPermission()
+    {
+        var permissionClient = _servicesFixture.ServiceProvider.GetService<ICasdoorClient>();
+        string name = "Permission_" + new DateTimeOffset(DateTime.UtcNow).ToUnixTimeSeconds().ToString();
+        _testOutputHelper.WriteLine($"test with Permission name {name}");
+        string owner = "casbin";
+
+        CasdoorPermission permission = new CasdoorPermission()
+        {
+            Owner = owner,
+            Name = name,
+            CreatedTime = DateTime.Now.ToString(),
+            DisplayName = name,
+            Description = "Casdoor Website",
+            Users = new string[] { "casbin/*" },
+            Groups = new string[] { },
+            Roles = new string[] { },
+            Domains = new string[] { },
+            Model = "user-model-built-in",
+            ResourceType = "Application",
+            Resources = new string[] { "app-casbin" },
+            Actions = new string[] { "Read", "Write" },
+            Effect = "Allow",
+            IsEnabled = true,
+        };
+
+        // Add the object
+        Task<CasdoorResponse?> responseAsync = permissionClient.AddPermissionAsync(permission);
+        CasdoorResponse? response = await responseAsync;
+        _testOutputHelper.WriteLine($"{response.Status} {response.Msg}");
+        Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+        await Task.Delay(1000);
+
+        // Get all objects, check if our added object is inside the list
+        Task<IEnumerable<CasdoorPermission>?> permissionAsyncs = permissionClient.GetPermissionsAsync(owner);
+        IEnumerable<CasdoorPermission>? getPermissions = await permissionAsyncs;
+        Assert.True(getPermissions.Any());
+        _testOutputHelper.WriteLine($"{getPermissions.Count()}");
+        bool found = false;
+        foreach (CasdoorPermission casdoorPermission in getPermissions)
+        {
+            _testOutputHelper.WriteLine(casdoorPermission.Name);
+            if (casdoorPermission.Name == name)
+            {
+                found = true;
+            }
+        }
+
+        Assert.True(found);
+
+        // Get the object
+        Task<CasdoorPermission?> PermissionAsync = permissionClient.GetPermissionAsync($"{owner}/{ name}");
+        CasdoorPermission ? getPermission = await PermissionAsync;
+        Assert.Equal(name, getPermission.Name);
+
+        // Update the object
+        string updatedDescription = "Updated Code";
+        getPermission.Description = updatedDescription;
+        responseAsync = permissionClient.UpdatePermissionAsync(getPermission, "");
+        response = await responseAsync;
+        Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+        // Validate the update
+        PermissionAsync = permissionClient.GetPermissionAsync($"{owner}/{name}");
+        getPermission = await PermissionAsync;
+        Assert.Equal(updatedDescription, getPermission.Description);
+
+        // Delete the object
+        responseAsync = permissionClient.DeletePermissionAsync(permission);
+        response = await responseAsync;
+        Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+        // Validate the deletion
+        PermissionAsync = permissionClient.GetPermissionAsync($"{owner}/{name}");
+        getPermission = await PermissionAsync;
+        Assert.Null(getPermission);
+    }
+}

--- a/tests/Casdoor.Client.UnitTests/ApiClientTests/PricingTest.cs
+++ b/tests/Casdoor.Client.UnitTests/ApiClientTests/PricingTest.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Casdoor.Client.UnitTests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+using static System.Net.Mime.MediaTypeNames;
+
+namespace Casdoor.Client.UnitTests.ApiClientTests
+{
+    public class PricingTest : IClassFixture<ServicesFixture>
+    {
+        private readonly ServicesFixture _servicesFixture;
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public PricingTest(ServicesFixture servicesFixture, ITestOutputHelper testOutputHelper)
+        {
+            _servicesFixture = servicesFixture;
+            _testOutputHelper = testOutputHelper;
+        }
+
+        [Fact]
+        public async void TestPricing()
+        {
+            var userClient = _servicesFixture.ServiceProvider.GetService<ICasdoorClient>();
+
+            const string ownerName = "casbin";
+            string name = "Pricing_" + new DateTimeOffset(DateTime.UtcNow).ToUnixTimeSeconds().ToString();
+
+            var pricing = new CasdoorPricing()
+            {
+                Owner = ownerName,
+                Name = name,
+                CreatedTime = DateTime.Now.ToString(CultureInfo.InvariantCulture),
+                DisplayName = name,
+                Application = "app-admin",
+		        Description = "Casdoor Website",
+            };
+
+            // Add a new object
+            Task<CasdoorResponse?> responseAsync = userClient.AddPricingAsync(pricing);
+            CasdoorResponse? response = await responseAsync;
+            _testOutputHelper.WriteLine($"{response.Status} {response.Msg}");
+            Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+            // Get all objects, check if our added object is inside the list
+            Task<IEnumerable<CasdoorPricing>?> pricingsAsync = userClient.GetPricingsAsync();
+            IEnumerable<CasdoorPricing>? getPricings = await pricingsAsync;
+            Assert.True(getPricings.Any());
+            _testOutputHelper.WriteLine($"{getPricings.Count()}");
+            bool found = false;
+            foreach (CasdoorPricing casdoorPricing in getPricings)
+            {
+                _testOutputHelper.WriteLine(casdoorPricing.Name);
+                if (casdoorPricing.Name == name)
+                {
+                    found = true;
+                }
+            }
+
+            Assert.True(found);
+
+            // Get the object
+            Task<CasdoorPricing?> pricingAsync = userClient.GetPricingAsync(name);
+            CasdoorPricing? getPricing = await pricingAsync;
+            Assert.Equal(name, getPricing.Name);
+
+            // Update the object
+            const string updatedDescription = "Updated Casdoor Pricing";
+            pricing.Description = updatedDescription;
+
+            // Update the object
+            responseAsync = userClient.UpdatePricingAsync(pricing);
+            response = await responseAsync;
+            Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+            // Validate the update
+            pricingAsync = userClient.GetPricingAsync(name);
+            getPricing = await pricingAsync;
+            Assert.Equal(updatedDescription, getPricing.Description);
+
+            // Delete the object
+            responseAsync = userClient.DeletePricingAsync(getPricing);
+            response = await responseAsync;
+            Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+            // Validate the deletion
+            pricingAsync = userClient.GetPricingAsync(name);
+            getPricing = await pricingAsync;
+            Assert.Null(getPricing);
+        }
+    }
+}

--- a/tests/Casdoor.Client.UnitTests/ApiClientTests/ProductTest.cs
+++ b/tests/Casdoor.Client.UnitTests/ApiClientTests/ProductTest.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Casdoor.Client.UnitTests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+using static System.Net.Mime.MediaTypeNames;
+
+namespace Casdoor.Client.UnitTests.ApiClientTests
+{
+    public class ProductTest : IClassFixture<ServicesFixture>
+    {
+        private readonly ServicesFixture _servicesFixture;
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public ProductTest(ServicesFixture servicesFixture, ITestOutputHelper testOutputHelper)
+        {
+            _servicesFixture = servicesFixture;
+            _testOutputHelper = testOutputHelper;
+        }
+
+        [Fact]
+        public async void TestProduct()
+        {
+            var userClient = _servicesFixture.ServiceProvider.GetService<ICasdoorClient>();
+
+            const string ownerName = "casbin";
+            string name = "Product_" + new DateTimeOffset(DateTime.UtcNow).ToUnixTimeSeconds().ToString();
+
+            var product = new CasdoorProduct()
+            {
+                Owner = ownerName,
+                Name = name,
+                CreatedTime = DateTime.Now.ToString(CultureInfo.InvariantCulture),
+                DisplayName = name,
+                Image = "https://cdn.casbin.org/img/casdoor-logo_1185x256.png",
+                Description = "Casdoor Website",
+                Tag = "auto_created_product_for_plan",
+                Quantity = 999,
+                Sold = 0,
+                State = "Published"
+            };
+
+            // Add a new object
+            Task<CasdoorResponse?> responseAsync = userClient.AddProductAsync(product);
+            CasdoorResponse? response = await responseAsync;
+            _testOutputHelper.WriteLine($"{response.Status} {response.Msg}");
+            Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+            // Get all objects, check if our added object is inside the list
+            Task<IEnumerable<CasdoorProduct>?> productsAsync = userClient.GetProductsAsync();
+            IEnumerable<CasdoorProduct>? getProducts = await productsAsync;
+            Assert.True(getProducts.Any());
+            _testOutputHelper.WriteLine($"{getProducts.Count()}");
+            bool found = false;
+            foreach (CasdoorProduct casdoorProduct in getProducts)
+            {
+                _testOutputHelper.WriteLine(casdoorProduct.Name);
+                if (casdoorProduct.Name == name)
+                {
+                    found = true;
+                }
+            }
+
+            Assert.True(found);
+
+            // Get the object
+            Task<CasdoorProduct?> productAsync = userClient.GetProductAsync(name);
+            CasdoorProduct? getProduct = await productAsync;
+            Assert.Equal(name, getProduct.Name);
+
+            // Update the object
+            const string updatedDescription = "Updated Casdoor Product";
+            product.Description = updatedDescription;
+
+            // Update the object
+            responseAsync = userClient.UpdateProductAsync(product);
+            response = await responseAsync;
+            Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+            // Validate the update
+            productAsync = userClient.GetProductAsync(name);
+            getProduct = await productAsync;
+            Assert.Equal(updatedDescription, getProduct.Description);
+
+            // Delete the object
+            responseAsync = userClient.DeleteProductAsync(getProduct);
+            response = await responseAsync;
+            Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+            // Validate the deletion
+            productAsync = userClient.GetProductAsync(name);
+            getProduct = await productAsync;
+            Assert.Null(getProduct);
+        }
+    }
+}

--- a/tests/Casdoor.Client.UnitTests/ApiClientTests/ProviderTest.cs
+++ b/tests/Casdoor.Client.UnitTests/ApiClientTests/ProviderTest.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Casdoor.Client.UnitTests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+using static System.Net.Mime.MediaTypeNames;
+
+namespace Casdoor.Client.UnitTests.ApiClientTests
+{
+    public class ProviderTest : IClassFixture<ServicesFixture>
+    {
+        private readonly ServicesFixture _servicesFixture;
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public ProviderTest(ServicesFixture servicesFixture, ITestOutputHelper testOutputHelper)
+        {
+            _servicesFixture = servicesFixture;
+            _testOutputHelper = testOutputHelper;
+        }
+
+        [Fact]
+        public async void TestProvider()
+        {
+            var userClient = _servicesFixture.ServiceProvider.GetService<ICasdoorClient>();
+
+            const string ownerName = "admin";
+            string name = "Provider_" + new DateTimeOffset(DateTime.UtcNow).ToUnixTimeSeconds().ToString();
+
+            var provider = new CasdoorProvider()
+            {
+                Owner = ownerName,
+                Name = name,
+                CreatedTime = DateTime.Now.ToString(CultureInfo.InvariantCulture),
+                DisplayName = name,
+                Category = "Captcha",
+                Type = "Default"
+            };
+
+            // Add a new object
+            Task<CasdoorResponse?> responseAsync = userClient.AddProviderAsync(provider);
+            CasdoorResponse? response = await responseAsync;
+            _testOutputHelper.WriteLine($"{response.Status} {response.Msg}");
+            Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+            // Get all objects, check if our added object is inside the list
+            Task<IEnumerable<CasdoorProvider>?> providersAsync = userClient.GetProvidersAsync();
+            IEnumerable<CasdoorProvider>? getProviders = await providersAsync;
+            Assert.True(getProviders.Any());
+            _testOutputHelper.WriteLine($"{getProviders.Count()}");
+            bool found = false;
+            foreach (CasdoorProvider casdoorProvider in getProviders)
+            {
+                _testOutputHelper.WriteLine(casdoorProvider.Name);
+                if (casdoorProvider.Name == name)
+                {
+                    found = true;
+                }
+            }
+
+            Assert.True(found);
+
+            // Get the object
+            Task<CasdoorProvider?> providerAsync = userClient.GetProviderAsync(name);
+            CasdoorProvider? getProvider = await providerAsync;
+            Assert.Equal(name, getProvider.Name);
+
+            // Update the object
+            const string updatedDisplayName = "Updated Casdoor Website";
+            provider.DisplayName = updatedDisplayName;
+
+            // Update the object
+            responseAsync = userClient.UpdateProviderAsync(provider.Name, provider);
+            response = await responseAsync;
+            Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+            // Validate the update
+            providerAsync = userClient.GetProviderAsync(name);
+            getProvider = await providerAsync;
+            Assert.Equal(updatedDisplayName, getProvider.DisplayName);
+
+            // Delete the object
+            responseAsync = userClient.DeleteProviderAsync(name);
+            response = await responseAsync;
+            Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+            // Validate the deletion
+            providerAsync = userClient.GetProviderAsync(name);
+            getProvider = await providerAsync;
+            Assert.Null(getProvider);
+        }
+    }
+}

--- a/tests/Casdoor.Client.UnitTests/ApiClientTests/ResourceTest.cs
+++ b/tests/Casdoor.Client.UnitTests/ApiClientTests/ResourceTest.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Casdoor.Client.UnitTests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+using NuGet.Frameworks;
+using Xunit.Abstractions;
+
+namespace Casdoor.Client.UnitTests.ApiClientTests;
+
+public class ResourceTest : IClassFixture<ServicesFixture>
+{
+    private readonly ServicesFixture _servicesFixture;
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public ResourceTest(ServicesFixture servicesFixture, ITestOutputHelper testOutputHelper)
+    {
+        _servicesFixture = servicesFixture;
+        _testOutputHelper = testOutputHelper;
+    }
+
+    [Fact]
+    public async void TestResource()
+    {
+        var resourceClient = _servicesFixture.ServiceProvider.GetService<ICasdoorClient>();
+        //string name = "Resource_" + new DateTimeOffset(DateTime.UtcNow).ToUnixTimeSeconds().ToString();
+        
+        string owner = "casbin";
+        string filename = "ResourceUploadTest.txt";
+
+        string path = $"Examples/{filename}";
+        string name = $"/casdoor/{filename}";
+        _testOutputHelper.WriteLine($"test with resource name {name}");
+        Assert.True(File.Exists(path));
+
+        FileStream fs = File.OpenRead(path);
+        
+
+        CasdoorUserResource resource = new CasdoorUserResource()
+        {
+            Owner = owner,
+            Name = name,
+            CreatedTime = DateTime.Now.ToString(),
+            Description = "Casdoor Website",
+            User = "casbin",
+            FileName = filename,
+            FileSize = fs.Length,
+            Tag = name
+        };
+
+        // Add the object
+        Task<CasdoorResponse?> responseAsync = resourceClient.UploadResourceAsync(resource.User, resource.Tag, "", resource.FileName, fs);
+        CasdoorResponse? response = await responseAsync;
+        _testOutputHelper.WriteLine($"{response.Status} {response.Msg}");
+        Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+        await Task.Delay(1000);
+
+        // Get all objects, check if our added object is inside the list
+        Task<IEnumerable<CasdoorUserResource>?> resourceAsyncs = resourceClient.GetResourcesAsync(owner, "casbin", "", "", "", "");
+        IEnumerable<CasdoorUserResource>? getResources = await resourceAsyncs;
+        Assert.True(getResources.Any());
+        _testOutputHelper.WriteLine($"{getResources.Count()}");
+        bool found = false;
+        foreach (CasdoorUserResource casdoorResource in getResources)
+        {
+            _testOutputHelper.WriteLine(casdoorResource.Name);
+            if (casdoorResource.Tag == name)
+            {
+                found = true;
+            }
+        }
+
+        Assert.True(found);
+
+        // Get the object
+        Task<CasdoorUserResource?> resourceAsync = resourceClient.GetResourceAsync(name);
+        CasdoorUserResource? getResource = await resourceAsync;
+        Assert.Equal(name, getResource.Tag);
+
+        // Delete the object
+        responseAsync = resourceClient.DeleteResourceAsync(name);
+        response = await responseAsync;
+        Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+        // Validate the deletion
+        resourceAsync = resourceClient.GetResourceAsync(name);
+        getResource = await resourceAsync;
+        Assert.Null(getResource);
+    }
+}

--- a/tests/Casdoor.Client.UnitTests/ApiClientTests/RoleTest.cs
+++ b/tests/Casdoor.Client.UnitTests/ApiClientTests/RoleTest.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Casdoor.Client.UnitTests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+using static System.Net.Mime.MediaTypeNames;
+
+namespace Casdoor.Client.UnitTests.ApiClientTests
+{
+    public class RoleTest : IClassFixture<ServicesFixture>
+    {
+        private readonly ServicesFixture _servicesFixture;
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public RoleTest(ServicesFixture servicesFixture, ITestOutputHelper testOutputHelper)
+        {
+            _servicesFixture = servicesFixture;
+            _testOutputHelper = testOutputHelper;
+        }
+
+        [Fact]
+        public async void TestRole()
+        {
+            var userClient = _servicesFixture.ServiceProvider.GetService<ICasdoorClient>();
+
+            const string ownerName = "admin";
+            string name = "Role_" + new DateTimeOffset(DateTime.UtcNow).ToUnixTimeSeconds().ToString();
+            _testOutputHelper.WriteLine($"start with name: {name}");
+
+            var role = new CasdoorRole()
+            {
+                Owner = ownerName,
+                Name = name,
+                CreatedTime = DateTime.Now.ToString(CultureInfo.InvariantCulture),
+                DisplayName = name,
+                Description = "Casdoor Website"
+            };
+
+            // Add a new object
+            Task<CasdoorResponse?> responseAsync = userClient.AddRoleAsync(role);
+            CasdoorResponse? response = await responseAsync;
+            _testOutputHelper.WriteLine($"{response.Status} {response.Msg}");
+            Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+            // Get all objects, check if our added object is inside the list
+            Task<IEnumerable<CasdoorRole>?> rolesAsync = userClient.GetRolesAsync();
+            IEnumerable<CasdoorRole>? getRoles = await rolesAsync;
+            Assert.True(getRoles.Any());
+            _testOutputHelper.WriteLine($"{getRoles.Count()}");
+            bool found = false;
+            foreach (CasdoorRole casdoorRole in getRoles)
+            {
+                _testOutputHelper.WriteLine(casdoorRole.Name);
+                if (casdoorRole.Name == name)
+                {
+                    found = true;
+                }
+            }
+
+            Assert.True(found);
+
+            // Get the object
+            Task<CasdoorRole?> roleAsync = userClient.GetRoleAsync(name);
+            CasdoorRole? getRole = await roleAsync;
+            Assert.Equal(name, getRole.Name);
+
+            // Update the object
+            const string updatedDescription = "Updated Casdoor Website";
+            role.Description = updatedDescription;
+
+            // Update the object
+            responseAsync = userClient.UpdateRoleAsync(role, role.Name);
+            response = await responseAsync;
+            Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+            // Validate the update
+            roleAsync = userClient.GetRoleAsync(name);
+            getRole = await roleAsync;
+            Assert.Equal(updatedDescription, getRole.Description);
+
+            // Delete the object
+            responseAsync = userClient.DeleteRoleAsync(getRole);
+            response = await responseAsync;
+            Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+            // Validate the deletion
+            roleAsync = userClient.GetRoleAsync(name);
+            getRole = await roleAsync;
+            Assert.Null(getRole);
+        }
+    }
+}

--- a/tests/Casdoor.Client.UnitTests/ApiClientTests/SessionTest.cs
+++ b/tests/Casdoor.Client.UnitTests/ApiClientTests/SessionTest.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Casdoor.Client.UnitTests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+using static System.Net.Mime.MediaTypeNames;
+
+namespace Casdoor.Client.UnitTests.ApiClientTests
+{
+    public class SessionTest : IClassFixture<ServicesFixture>
+    {
+        private readonly ServicesFixture _servicesFixture;
+        private readonly ITestOutputHelper _testOutputHelper;
+
+        public SessionTest(ServicesFixture servicesFixture, ITestOutputHelper testOutputHelper)
+        {
+            _servicesFixture = servicesFixture;
+            _testOutputHelper = testOutputHelper;
+        }
+
+        [Fact]
+        public async void TestSession()
+        {
+            var userClient = _servicesFixture.ServiceProvider.GetService<ICasdoorClient>();
+
+            const string ownerName = "casbin";
+            string name = "Session_" + new DateTimeOffset(DateTime.UtcNow).ToUnixTimeSeconds().ToString();
+
+            var session = new CasdoorSession()
+            {
+                Owner = ownerName,
+                Name = name,
+                CreatedTime = DateTime.Now.ToString(CultureInfo.InvariantCulture),
+                Application = "app-built-in",
+                SessionId = new string[]{}
+            };
+
+            // Add a new object
+            Task<CasdoorResponse?> responseAsync = userClient.AddSessionAsync(session);
+            CasdoorResponse? response = await responseAsync;
+            _testOutputHelper.WriteLine($"{response.Status} {response.Msg}");
+            Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+            // Get all objects, check if our added object is inside the list
+            Task<IEnumerable<CasdoorSession>?> sessionsAsync = userClient.GetSessionsAsync();
+            IEnumerable<CasdoorSession>? getSessions = await sessionsAsync;
+            Assert.True(getSessions.Any());
+            _testOutputHelper.WriteLine($"{getSessions.Count()}");
+            bool found = false;
+            foreach (CasdoorSession casdoorSession in getSessions)
+            {
+                _testOutputHelper.WriteLine(casdoorSession.Name);
+                if (casdoorSession.Name == name)
+                {
+                    found = true;
+                }
+            }
+
+            Assert.True(found);
+
+            // Get the object
+            Task<CasdoorSession?> sessionAsync = userClient.GetSessionAsync(name, session.Application);
+            CasdoorSession? getSession = await sessionAsync;
+            Assert.Equal(name, getSession.Name);
+
+            // Update the object
+            string updatedTime = DateTime.Now.ToString(CultureInfo.InvariantCulture);
+            session.CreatedTime = updatedTime;
+
+            // Update the object
+            responseAsync = userClient.UpdateSessionAsync(session);
+            response = await responseAsync;
+            Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+            // Validate the update
+            sessionAsync = userClient.GetSessionAsync(name, session.Application);
+            getSession = await sessionAsync;
+            Assert.Equal(updatedTime, getSession.CreatedTime);
+
+            // Delete the object
+            responseAsync = userClient.DeleteSessionAsync(getSession);
+            response = await responseAsync;
+            Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+            // Validate the deletion
+            sessionAsync = userClient.GetSessionAsync(name, session.Application);
+            getSession = await sessionAsync;
+            Assert.Null(getSession);
+        }
+    }
+}

--- a/tests/Casdoor.Client.UnitTests/ApiClientTests/SubscriptionTest.cs
+++ b/tests/Casdoor.Client.UnitTests/ApiClientTests/SubscriptionTest.cs
@@ -26,7 +26,7 @@ public class SubscriptionTest : IClassFixture<ServicesFixture>
     public async void TestSubscription()
     {
         var userClient = _servicesFixture.ServiceProvider.GetService<ICasdoorClient>();
-        string name = "Subscription_" + DateTime.Now.ToLongTimeString().Substring(0, 6);
+        string name = "Subscription_" + DateTime.Now.ToLongTimeString();
 
         CasdoorSubscription subscription = new CasdoorSubscription()
         {

--- a/tests/Casdoor.Client.UnitTests/ApiClientTests/SubscriptionTest.cs
+++ b/tests/Casdoor.Client.UnitTests/ApiClientTests/SubscriptionTest.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Threading.Tasks;
+using Casdoor.Client.UnitTests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+
+namespace Casdoor.Client.UnitTests.ApiClientTests;
+
+public class SubscriptionTest : IClassFixture<ServicesFixture>
+{
+    private readonly ServicesFixture _servicesFixture;
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public SubscriptionTest(ServicesFixture servicesFixture, ITestOutputHelper testOutputHelper)
+    {
+        _servicesFixture = servicesFixture;
+        _testOutputHelper = testOutputHelper;
+    }
+
+    [Fact]
+    public async void TestSubscription()
+    {
+        var userClient = _servicesFixture.ServiceProvider.GetService<ICasdoorClient>();
+        string name = "Subscription_" + DateTime.Now.ToLongTimeString().Substring(0, 6);
+
+        CasdoorSubscription subscription = new CasdoorSubscription()
+        {
+            Owner = "admin",
+            Name = name,
+            CreatedTime = DateTime.Now.ToString(),
+            DisplayName = name,
+            Description = "Casdoor Website",
+        };
+
+        // Add the object
+        Task<CasdoorResponse?> responseAsync = userClient.AddSubscriptionAsync(subscription);
+        CasdoorResponse? response = await responseAsync;
+        _testOutputHelper.WriteLine($"{response.Status} {response.Msg}");
+        Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+        // Get all objects, check if our added object is inside the list
+        Task<IEnumerable<CasdoorSubscription>?> subscriptionAsyncs = userClient.GetSubscriptionsAsync("admin");
+        IEnumerable<CasdoorSubscription>? getSubscriptions = await subscriptionAsyncs;
+        Assert.True(getSubscriptions.Any());
+        _testOutputHelper.WriteLine($"{getSubscriptions.Count()}");
+        bool found = false;
+        foreach (CasdoorSubscription casdoorSubscription in getSubscriptions)
+        {
+            _testOutputHelper.WriteLine(casdoorSubscription.Name);
+            if (casdoorSubscription.Name == name)
+            {
+                found = true;
+            }
+        }
+
+        Assert.True(found);
+
+        // Get the object
+        Task<CasdoorSubscription?> subscriptionAsync = userClient.GetSubscriptionAsync("admin", name);
+        CasdoorSubscription? getSubscription = await subscriptionAsync;
+        Assert.Equal(name, getSubscription.Name);
+
+        // Update the object
+        string updateDescription = "Updated Casdoor Website";
+        subscription.Description = updateDescription;
+        responseAsync = userClient.UpdateSubscriptionAsync(subscription);
+        response = await responseAsync;
+        Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+        // Validate the update
+        subscriptionAsync = userClient.GetSubscriptionAsync("admin", name);
+        getSubscription = await subscriptionAsync;
+        Assert.Equal(updateDescription, getSubscription.Description);
+
+        // Delete the object
+        responseAsync = userClient.DeleteSubscriptionAsync(subscription);
+        response = await responseAsync;
+        Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+        // Validate the deletion
+        subscriptionAsync = userClient.GetSubscriptionAsync("admin", name);
+        getSubscription = await subscriptionAsync;
+        Assert.Null(getSubscription);
+    }
+}

--- a/tests/Casdoor.Client.UnitTests/ApiClientTests/SyncerTest.cs
+++ b/tests/Casdoor.Client.UnitTests/ApiClientTests/SyncerTest.cs
@@ -27,7 +27,7 @@ public class SyncerTest : IClassFixture<ServicesFixture>
     {
 
         var userClient = _servicesFixture.ServiceProvider.GetService<ICasdoorClient>();
-        string name = "Syncer_" + DateTime.Now.ToLongTimeString().Substring(0, 6);
+        string name = "Syncer_" + DateTime.Now.ToLongTimeString();
         string appName = $"admin/{name}";
 
         CasdoorSyncer syncer = new CasdoorSyncer()

--- a/tests/Casdoor.Client.UnitTests/ApiClientTests/SyncerTest.cs
+++ b/tests/Casdoor.Client.UnitTests/ApiClientTests/SyncerTest.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Threading.Tasks;
+using Casdoor.Client.UnitTests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+
+namespace Casdoor.Client.UnitTests.ApiClientTests;
+
+public class SyncerTest : IClassFixture<ServicesFixture>
+{
+    private readonly ServicesFixture _servicesFixture;
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public SyncerTest(ServicesFixture servicesFixture, ITestOutputHelper testOutputHelper)
+    {
+        _servicesFixture = servicesFixture;
+        _testOutputHelper = testOutputHelper;
+    }
+
+    [Fact]
+    public async void TestSyncer()
+    {
+
+        var userClient = _servicesFixture.ServiceProvider.GetService<ICasdoorClient>();
+        string name = "Syncer_" + DateTime.Now.ToLongTimeString().Substring(0, 6);
+        string appName = $"admin/{name}";
+
+        CasdoorSyncer syncer = new CasdoorSyncer()
+        {
+            Owner = "admin",
+            Name = name,
+            CreatedTime = DateTime.Now.ToString(),
+            Organization = "casbin",
+            Host = "localhost",
+            Port = 3306,
+            User = "root",
+            Password = "123",
+            DatabaseType = "mysql",
+            Database = "syncer_db",
+            Table = "user-table",
+            SyncInterval = 1,
+        };
+
+        // Add the object
+        Task<CasdoorResponse?> responseAsync = userClient.AddSyncerAsync(syncer);
+        CasdoorResponse? response = await responseAsync;
+        _testOutputHelper.WriteLine($"{response.Status} {response.Msg}");
+        Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+        // Get all objects, check if our added object is inside the list
+        Task<IEnumerable<CasdoorSyncer>?> syncerAsyncs = userClient.GetSyncersAsync("admin");
+        IEnumerable<CasdoorSyncer>? getSyncers = await syncerAsyncs;
+        Assert.True(getSyncers.Any());
+        _testOutputHelper.WriteLine($"{getSyncers.Count()}");
+        bool found = false;
+        foreach (CasdoorSyncer casdoorSyncer in getSyncers)
+        {
+            _testOutputHelper.WriteLine(casdoorSyncer.Name);
+            if (casdoorSyncer.Name == name)
+            {
+                found = true;
+            }
+        }
+
+        Assert.True(found);
+
+        // Get the object
+        Task<CasdoorSyncer?> syncerAsync = userClient.GetSyncerAsync("admin", name);
+        CasdoorSyncer? getSyncer = await syncerAsync;
+        Assert.Equal(name, getSyncer.Name);
+
+        // Update the object
+        getSyncer.SyncInterval = 200;
+        responseAsync = userClient.UpdateSyncerAsync(getSyncer);
+        response = await responseAsync;
+        Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+        //Validate the update
+        syncerAsync = userClient.GetSyncerAsync("admin", name);
+        getSyncer = await syncerAsync;
+        Assert.Equal(200, getSyncer.SyncInterval);
+
+        // Delete the object
+        responseAsync = userClient.DeleteSyncerAsync(syncer);
+        response = await responseAsync;
+        Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+        // Validate the deletion
+        syncerAsync = userClient.GetSyncerAsync("admin", name);
+        getSyncer = await syncerAsync;
+        Assert.Null(getSyncer);
+
+    }
+}

--- a/tests/Casdoor.Client.UnitTests/ApiClientTests/TokenTest.cs
+++ b/tests/Casdoor.Client.UnitTests/ApiClientTests/TokenTest.cs
@@ -1,0 +1,88 @@
+﻿using System.Globalization;
+using Casdoor.Client.UnitTests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+
+namespace Casdoor.Client.UnitTests.ApiClientTests;
+
+public class TokenTest : IClassFixture<ServicesFixture>
+{
+    private readonly ServicesFixture _servicesFixture;
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public TokenTest(ServicesFixture servicesFixture, ITestOutputHelper testOutputHelper)
+    {
+        _servicesFixture = servicesFixture;
+        _testOutputHelper = testOutputHelper;
+    }
+
+    [Fact]
+    public async void TestToken()
+    {
+        var tokenClient = _servicesFixture.ServiceProvider.GetService<ICasdoorClient>();
+        string name = "Token_" + new DateTimeOffset(DateTime.UtcNow).ToUnixTimeSeconds().ToString();
+        _testOutputHelper.WriteLine($"test with token name {name}");
+        string owner = "admin";
+
+        CasdoorToken token = new CasdoorToken()
+        {
+            Owner = owner,
+            Name = name,
+            CreatedTime = DateTime.Now.ToString(),
+            Code = "abc",
+            AccessToken = "123456"
+        };
+
+        // Add the object
+        Task<CasdoorResponse?> responseAsync = tokenClient.AddTokenAsync(token);
+        CasdoorResponse? response = await responseAsync;
+        _testOutputHelper.WriteLine($"{response.Status} {response.Msg}");
+        Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+        await Task.Delay(1000);
+
+        // Get all objects, check if our added object is inside the list
+        Task<IEnumerable<CasdoorToken>?> tokenAsyncs = tokenClient.GetTokensAsync(owner);
+        IEnumerable<CasdoorToken>? getTokens = await tokenAsyncs;
+        Assert.True(getTokens.Any());
+        _testOutputHelper.WriteLine($"{getTokens.Count()}");
+        bool found = false;
+        foreach (CasdoorToken casdoorToken in getTokens)
+        {
+            _testOutputHelper.WriteLine(casdoorToken.Name);
+            if (casdoorToken.Name == name)
+            {
+                found = true;
+            }
+        }
+
+        Assert.True(found);
+        
+        // Get the object
+        Task<CasdoorToken?> tokenAsync = tokenClient.GetTokenAsync(owner, name);
+        CasdoorToken? getToken = await tokenAsync;
+        Assert.Equal(name, getToken.Name);
+
+        // Update the object
+        string updatedCode = "Updated Code";
+        getToken.Code = updatedCode;
+        responseAsync = tokenClient.UpdateTokenAsync(getToken, new List<string>());
+        response = await responseAsync;
+        Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+        // Validate the update
+        tokenAsync = tokenClient.GetTokenAsync(owner, name);
+        getToken = await tokenAsync;
+        Assert.Equal(updatedCode, getToken.Code);
+
+        // Delete the object
+        responseAsync = tokenClient.DeleteTokenAsync(token);
+        response = await responseAsync;
+        Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+        // Validate the deletion
+        tokenAsync = tokenClient.GetTokenAsync(owner, name);
+        getToken = await tokenAsync;
+        Assert.Null(getToken);
+    }
+}

--- a/tests/Casdoor.Client.UnitTests/ApiClientTests/UserTest.cs
+++ b/tests/Casdoor.Client.UnitTests/ApiClientTests/UserTest.cs
@@ -1,0 +1,85 @@
+﻿using System.Globalization;
+using Casdoor.Client.UnitTests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+
+namespace Casdoor.Client.UnitTests.ApiClientTests;
+
+public class UserTest : IClassFixture<ServicesFixture>
+{
+    private readonly ServicesFixture _servicesFixture;
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public UserTest(ServicesFixture servicesFixture, ITestOutputHelper testOutputHelper)
+    {
+        _servicesFixture = servicesFixture;
+        _testOutputHelper = testOutputHelper;
+    }
+
+    [Fact]
+    public async void TestUser()
+    {
+        var userClient = _servicesFixture.ServiceProvider.GetService<ICasdoorClient>();
+        string name = "User_" + new DateTimeOffset(DateTime.UtcNow).ToUnixTimeSeconds().ToString();
+        _testOutputHelper.WriteLine($"test with username {name}");
+        string appName = $"admin/{name}";
+        string owner = "casbin";
+
+        CasdoorUser user = new CasdoorUser()
+        {
+            Owner = owner,
+            Name = name,
+            CreatedTime = DateTime.Now.ToString(),
+            DisplayName = name,
+        };
+
+        // Add the object
+        Task<CasdoorResponse?> responseAsync = userClient.AddUserAsync(user);
+        CasdoorResponse? response = await responseAsync;
+        _testOutputHelper.WriteLine($"{response.Status} {response.Msg}");
+        Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+        // Get all objects, check if our added object is inside the list
+        Task<IEnumerable<CasdoorUser>?> userAsyncs = userClient.GetUsersAsync(owner);
+        IEnumerable<CasdoorUser>? getUsers = await userAsyncs;
+        Assert.True(getUsers.Any());
+        _testOutputHelper.WriteLine($"{getUsers.Count()}");
+        bool found = false;
+        foreach (CasdoorUser casdoorUser in getUsers)
+        {
+            _testOutputHelper.WriteLine(casdoorUser.Name);
+            if (casdoorUser.Name == name)
+            {
+                found = true;
+            }
+        }
+
+        Assert.True(found);
+
+        // Get the object
+        Task<CasdoorUser?> userAsync = userClient.GetUserAsync(name, owner);
+        CasdoorUser? getUser = await userAsync;
+        Assert.Equal(name, getUser.Name);
+
+        // Update the object
+        getUser.DisplayName = "Updated Casdoor Website";
+        responseAsync = userClient.UpdateUserAsync(getUser, null);
+        response = await responseAsync;
+        Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+        // Validate the update
+        userAsync = userClient.GetUserAsync(name, owner);
+        getUser = await userAsync;
+        Assert.Equal("Updated Casdoor Website", getUser.DisplayName);
+
+        // Delete the object
+        responseAsync = userClient.DeleteUserAsync(user.Name);
+        response = await responseAsync;
+        Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+        // Validate the deletion
+        userAsync = userClient.GetUserAsync(name, owner);
+        getUser = await userAsync;
+        Assert.Null(getUser);
+    }
+}

--- a/tests/Casdoor.Client.UnitTests/ApiClientTests/WebhookTest.cs
+++ b/tests/Casdoor.Client.UnitTests/ApiClientTests/WebhookTest.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Threading.Tasks;
+using Casdoor.Client.UnitTests.Fixtures;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit.Abstractions;
+
+namespace Casdoor.Client.UnitTests.ApiClientTests;
+
+public class WebhookTest : IClassFixture<ServicesFixture>
+{
+    private readonly ServicesFixture _servicesFixture;
+    private readonly ITestOutputHelper _testOutputHelper;
+
+    public WebhookTest(ServicesFixture servicesFixture, ITestOutputHelper testOutputHelper)
+    {
+        _servicesFixture = servicesFixture;
+        _testOutputHelper = testOutputHelper;
+    }
+
+    [Fact]
+    public async void TestWebhook()
+    {
+
+        var userClient = _servicesFixture.ServiceProvider.GetService<ICasdoorClient>();
+        string name = "Webhook_" + DateTime.Now.ToLongTimeString().Substring(0, 6);
+        string appName = $"admin/{name}";
+
+        CasdoorWebhook webhook = new CasdoorWebhook()
+        {
+            Owner= "casbin",
+		    Name = name,
+		    CreatedTime = DateTime.Now.ToString(),
+		    Organization = "casbin",
+        };
+
+        // Add the object
+        Task<CasdoorResponse?> responseAsync = userClient.AddWebhookAsync(webhook); 
+        CasdoorResponse? response = await responseAsync;
+        _testOutputHelper.WriteLine($"{response.Status} {response.Msg}");
+        Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+        // Get all objects, check if our added object is inside the list
+        Task<IEnumerable<CasdoorWebhook>?> webhookAsyncs = userClient.GetWebhooksAsync("casbin"); 
+        IEnumerable<CasdoorWebhook>? getWebhooks = await webhookAsyncs;
+        Assert.True(getWebhooks.Any());
+        _testOutputHelper.WriteLine($"{getWebhooks.Count()}");
+        bool found = false;
+        foreach (CasdoorWebhook casdoorWebhook in getWebhooks)
+        {
+            _testOutputHelper.WriteLine(casdoorWebhook.Name);
+            if (casdoorWebhook.Name == name)
+            {
+                found = true;
+            }
+        }
+
+        Assert.True(found);
+
+        // Get the object
+        Task<CasdoorWebhook?> webhookAsync = userClient.GetWebhookAsync("casbin", name);  
+        CasdoorWebhook? getWebhook = await webhookAsync;
+        Assert.Equal(name, getWebhook.Name);
+
+        // Update the object
+        webhook.Organization = "admin";
+        responseAsync = userClient.UpdateWebhookAsync(webhook); 
+        response = await responseAsync;
+        Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+
+        //Validate the update
+        webhookAsync = userClient.GetWebhookAsync("casbin", name); 
+        getWebhook = await webhookAsync;
+        Assert.Equal("admin", getWebhook.Organization);
+
+        // Delete the object
+        responseAsync = userClient.DeleteWebhookAsync(webhook);  // 修改为 DeleteWebhookAsync
+        response = await responseAsync;
+        Assert.Equal(CasdoorConstants.DefaultCasdoorSuccessStatus, response.Status);
+        // Validate the deletion
+        webhookAsync = userClient.GetWebhookAsync("casbin", name);  // 修改为 GetWebhookAsync
+        getWebhook = await webhookAsync;
+        Assert.Null(getWebhook);
+
+    }
+}

--- a/tests/Casdoor.Client.UnitTests/ApiClientTests/WebhookTest.cs
+++ b/tests/Casdoor.Client.UnitTests/ApiClientTests/WebhookTest.cs
@@ -27,7 +27,7 @@ public class WebhookTest : IClassFixture<ServicesFixture>
     {
 
         var userClient = _servicesFixture.ServiceProvider.GetService<ICasdoorClient>();
-        string name = "Webhook_" + DateTime.Now.ToLongTimeString().Substring(0, 6);
+        string name = "Webhook_" + DateTime.Now.ToLongTimeString();
         string appName = $"admin/{name}";
 
         CasdoorWebhook webhook = new CasdoorWebhook()

--- a/tests/Casdoor.Client.UnitTests/Casdoor.Client.UnitTests.csproj
+++ b/tests/Casdoor.Client.UnitTests/Casdoor.Client.UnitTests.csproj
@@ -25,4 +25,10 @@
     <ProjectReference Include="..\..\src\Casdoor.Client\Casdoor.Client.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="Examples\ResourceUploadTest.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/tests/Casdoor.Client.UnitTests/Examples/ResourceUploadTest.txt
+++ b/tests/Casdoor.Client.UnitTests/Examples/ResourceUploadTest.txt
@@ -1,0 +1,1 @@
+﻿ResourceUploadTest


### PR DESCRIPTION
Fix: https://github.com/casdoor/casdoor-dotnet-sdk/issues/64